### PR TITLE
Osiris/reth compatibility

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -93,7 +93,7 @@ impl EngineApiServer for EthEngineApi {
         };
 
         if should_send_to_builder {
-            // async call to builder to trigger payload building and sync
+            // async call to the builder, and l2_client to start the payload building process
             let builder = self.builder_client.clone();
             let attr = payload_attributes.clone();
             let f = async {


### PR DESCRIPTION
**Overview**
- This PR removes the assumption that the build process id of the builder matches the build process id of the l2 client. 

When testing with a reth builder the process id's didn't match which downstream caused issues in `get_payload_v3` when trying to grab the payload from the builder. 

**Solution**
- Ephemerally map the build process id of the l2 client to the build process id of the builder in `fork_choice_update_v3` when a build process has been started.
- The downside here is we now need to wait for both futures to resolve in `fork_choice_update_v3`

Note: This has been load tested with both a Reth builder, and a op-geth builder in a rollup devnet. 