### PR TITLE
docker: Allow container to run on ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ COPY . .
 RUN cargo build --release
 
 FROM debian:stable-slim AS runtime
+
+RUN apt-get update && apt-get install -y libssl3
+
 WORKDIR /app
 COPY --from=builder /app/target/release/rollup-boost /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/rollup-boost"]


### PR DESCRIPTION
Allow container to run on ubuntu, otherwise we'll encounter issue `/usr/local/bin/rollup-boost: error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory`