### PR TITLE
chore: local -> external builder mapping

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -662,11 +662,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_server() {
-        let _ = tracing_subscriber::fmt::try_init();
-
         engine_success().await;
         boost_sync_enabled().await;
         builder_payload_err().await;
+        test_local_external_payload_ids_different().await;
+        test_local_external_payload_ids_same().await;
     }
 
     async fn engine_success() {
@@ -866,7 +866,6 @@ mod tests {
         server.start(module)
     }
 
-    #[tokio::test]
     async fn test_local_external_payload_ids_same() {
         let same_id = PayloadId::new([0, 0, 0, 0, 0, 0, 0, 42]);
 
@@ -916,7 +915,6 @@ mod tests {
         test_harness.cleanup().await;
     }
 
-    #[tokio::test]
     async fn test_local_external_payload_ids_different() {
         let local_id = PayloadId::new([1, 2, 3, 4, 5, 6, 7, 8]);
         let external_id = PayloadId::new([9, 9, 9, 9, 9, 9, 9, 9]);


### PR DESCRIPTION
# Overview
This PR adds payload ID mapping functionality to track and map between local and external payload IDs when interacting with the builder node. This ensures proper correlation between payloads across different nodes.

Key changes:
- Added `local_to_external_payload_ids` cache to `PayloadTraceContext` to store mappings
- Added methods to store and retrieve payload ID mappings
- Updated `get_payload_v3` to use external payload ID when requesting from builder
- Added payload ID mapping in `fork_choice_updated_v3` response handling
- Added logging improvements to track both local and external payload IDs

The changes help maintain proper tracing and correlation between local execution engine payloads and external builder payloads, improving debuggability and reliability of the system.


fixes #46 