### PR TITLE
feat(da-throttling): Forward `miner_` requests to the builder

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -9,7 +9,7 @@ use std::{future::Future, pin::Pin};
 use tower::{Layer, Service};
 use tracing::debug;
 
-const MULTIPLEX_METHODS: [&str; 2] = ["engine_", "eth_sendRawTransaction"];
+const MULTIPLEX_METHODS: [&str; 3] = ["engine_", "eth_sendRawTransaction", "miner_"];
 
 #[derive(Debug, Clone)]
 pub struct ProxyLayer {

--- a/src/server.rs
+++ b/src/server.rs
@@ -216,7 +216,7 @@ where
 {
     async fn set_max_da_size(&self, bytes: Bytes) -> RpcResult<bool> {
         debug!(
-            message = "received set_max_da_size",
+            message = "received miner_setMaxDASize",
             "bytes_len" = bytes.len()
         );
 
@@ -225,7 +225,7 @@ where
         let tx_bytes = bytes.clone();
         tokio::spawn(async move {
             builder_client.set_max_da_size(tx_bytes).await.map_err(|e| {
-                error!(message = "error calling set_max_da_size for builder", "url" =url, "error" = %e);
+                error!(message = "error calling miner_setMaxDASize for builder", "url" =url, "error" = %e);
             })
         });
 
@@ -237,7 +237,7 @@ where
                 ClientError::Call(err) => err,
                 other_error => {
                     error!(
-                        message = "error calling set_max_da_size for l2 client",
+                        message = "error calling miner_setMaxDASize for l2 client",
                         "url" = self.l2_client.url,
                         "error" = %other_error,
                     );
@@ -247,14 +247,17 @@ where
     }
 
     async fn set_extra(&self, bytes: Bytes) -> RpcResult<bool> {
-        debug!(message = "received set_extra", "bytes_len" = bytes.len());
+        debug!(
+            message = "received miner_setExtra",
+            "bytes_len" = bytes.len()
+        );
 
         let builder_client = self.builder_client.client.clone();
         let url = self.builder_client.url.clone();
         let tx_bytes = bytes.clone();
         tokio::spawn(async move {
             builder_client.set_extra(tx_bytes).await.map_err(|e| {
-                error!(message = "error calling set_extra for builder", "url" =url, "error" = %e);
+                error!(message = "error calling miner_setExtra for builder", "url" =url, "error" = %e);
             })
         });
 
@@ -266,7 +269,7 @@ where
                 ClientError::Call(err) => err,
                 other_error => {
                     error!(
-                        message = "error calling set_extra for l2 client",
+                        message = "error calling miner_setExtra for l2 client",
                         "url" = self.l2_client.url,
                         "error" = %other_error,
                     );
@@ -277,7 +280,7 @@ where
 
     async fn set_gas_price(&self, bytes: Bytes) -> RpcResult<bool> {
         debug!(
-            message = "received set_gas_price",
+            message = "received miner_setGasPrice",
             "bytes_len" = bytes.len()
         );
 
@@ -286,7 +289,7 @@ where
         let tx_bytes = bytes.clone();
         tokio::spawn(async move {
             builder_client.set_gas_price(tx_bytes).await.map_err(|e| {
-                error!(message = "error calling set_gas_price for builder", "url" =url, "error" = %e);
+                error!(message = "error calling miner_setGasPrice for builder", "url" =url, "error" = %e);
             })
         });
 
@@ -298,7 +301,7 @@ where
                 ClientError::Call(err) => err,
                 other_error => {
                     error!(
-                        message = "error calling set_gas_price for l2 client",
+                        message = "error calling miner_setGasPrice for l2 client",
                         "url" = self.l2_client.url,
                         "error" = %other_error,
                     );

--- a/src/server.rs
+++ b/src/server.rs
@@ -938,7 +938,4 @@ mod tests {
             .unwrap();
         server.start(module)
     }
-
-    #[test]
-    fn test_set_extra() {}
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,6 +4,7 @@ use alloy_rpc_types_engine::{
     ExecutionPayload, ExecutionPayloadV3, ForkchoiceState, ForkchoiceUpdated, PayloadId,
     PayloadStatus,
 };
+use http::method;
 use jsonrpsee::core::{async_trait, ClientError, RpcResult};
 use jsonrpsee::http_client::transport::HttpBackend;
 use jsonrpsee::http_client::HttpClient;
@@ -116,6 +117,21 @@ pub trait EthApi {
     async fn send_raw_transaction(&self, bytes: Bytes) -> RpcResult<B256>;
 }
 
+#[rpc(server, client, namespace = "miner")]
+pub trait MinerApi {
+    #[method(name = "setMaxDASize")]
+    async fn set_max_da_size(&self, bytes: Bytes) -> RpcResult<bool>;
+
+    #[method(name = "setExtra")]
+    async fn set_extra(&self, bytes: Bytes) -> RpcResult<bool>;
+
+    #[method(name = "setGasPrice")]
+    async fn set_gas_price(&self, bytes: Bytes) -> RpcResult<bool>;
+
+    #[method(name = "setGasLimit")]
+    async fn set_gas_limit(&self, bytes: Bytes) -> RpcResult<bool>;
+}
+
 pub struct HttpClientWrapper<C = HttpClient<AuthClientService<HttpBackend>>> {
     pub client: C,
     pub url: String,
@@ -193,6 +209,8 @@ where
             })
     }
 }
+
+// TODO: set this for all the miner methods impl a trait or use one from reth
 
 #[async_trait]
 impl<C> EngineApiServer for EthEngineApi<HttpClientWrapper<C>>

--- a/src/server.rs
+++ b/src/server.rs
@@ -312,7 +312,7 @@ where
 
     async fn set_gas_limit(&self, bytes: Bytes) -> RpcResult<bool> {
         debug!(
-            message = "received set_gas_limit",
+            message = "received miner_setGasLimit",
             "bytes_len" = bytes.len()
         );
 
@@ -321,7 +321,7 @@ where
         let tx_bytes = bytes.clone();
         tokio::spawn(async move {
             builder_client.set_gas_limit(tx_bytes).await.map_err(|e| {
-                error!(message = "error calling set_gas_limit for builder", "url" =url, "error" = %e);
+                error!(message = "error calling miner_setGasLimit for builder", "url" =url, "error" = %e);
             })
         });
 
@@ -333,7 +333,7 @@ where
                 ClientError::Call(err) => err,
                 other_error => {
                     error!(
-                        message = "error calling set_gas_limit for l2 client",
+                        message = "error calling miner_setGasLimit for l2 client",
                         "url" = self.l2_client.url,
                         "error" = %other_error,
                     );
@@ -938,4 +938,7 @@ mod tests {
             .unwrap();
         server.start(module)
     }
+
+    #[test]
+    fn test_set_extra() {}
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -225,7 +225,7 @@ where
         let tx_bytes = bytes.clone();
         tokio::spawn(async move {
             builder_client.set_max_da_size(tx_bytes).await.map_err(|e| {
-                error!(message = "error calling set_max_da_size for builder", "url" = url, "error" = %e);
+                error!(message = "error calling set_max_da_size for builder", "url" =url, "error" = %e);
             })
         });
 
@@ -247,15 +247,96 @@ where
     }
 
     async fn set_extra(&self, bytes: Bytes) -> RpcResult<bool> {
-        todo!()
+        debug!(message = "received set_extra", "bytes_len" = bytes.len());
+
+        let builder_client = self.builder_client.client.clone();
+        let url = self.builder_client.url.clone();
+        let tx_bytes = bytes.clone();
+        tokio::spawn(async move {
+            builder_client.set_extra(tx_bytes).await.map_err(|e| {
+                error!(message = "error calling set_extra for builder", "url" =url, "error" = %e);
+            })
+        });
+
+        self.l2_client
+            .client
+            .set_extra(bytes)
+            .await
+            .map_err(|e| match e {
+                ClientError::Call(err) => err,
+                other_error => {
+                    error!(
+                        message = "error calling set_extra for l2 client",
+                        "url" = self.l2_client.url,
+                        "error" = %other_error,
+                    );
+                    ErrorCode::InternalError.into()
+                }
+            })
     }
 
     async fn set_gas_price(&self, bytes: Bytes) -> RpcResult<bool> {
-        todo!()
+        debug!(
+            message = "received set_gas_price",
+            "bytes_len" = bytes.len()
+        );
+
+        let builder_client = self.builder_client.client.clone();
+        let url = self.builder_client.url.clone();
+        let tx_bytes = bytes.clone();
+        tokio::spawn(async move {
+            builder_client.set_gas_price(tx_bytes).await.map_err(|e| {
+                error!(message = "error calling set_gas_price for builder", "url" =url, "error" = %e);
+            })
+        });
+
+        self.l2_client
+            .client
+            .set_gas_price(bytes)
+            .await
+            .map_err(|e| match e {
+                ClientError::Call(err) => err,
+                other_error => {
+                    error!(
+                        message = "error calling set_gas_price for l2 client",
+                        "url" = self.l2_client.url,
+                        "error" = %other_error,
+                    );
+                    ErrorCode::InternalError.into()
+                }
+            })
     }
 
     async fn set_gas_limit(&self, bytes: Bytes) -> RpcResult<bool> {
-        todo!()
+        debug!(
+            message = "received set_gas_limit",
+            "bytes_len" = bytes.len()
+        );
+
+        let builder_client = self.builder_client.client.clone();
+        let url = self.builder_client.url.clone();
+        let tx_bytes = bytes.clone();
+        tokio::spawn(async move {
+            builder_client.set_gas_limit(tx_bytes).await.map_err(|e| {
+                error!(message = "error calling set_gas_limit for builder", "url" =url, "error" = %e);
+            })
+        });
+
+        self.l2_client
+            .client
+            .set_gas_limit(bytes)
+            .await
+            .map_err(|e| match e {
+                ClientError::Call(err) => err,
+                other_error => {
+                    error!(
+                        message = "error calling set_gas_limit for l2 client",
+                        "url" = self.l2_client.url,
+                        "error" = %other_error,
+                    );
+                    ErrorCode::InternalError.into()
+                }
+            })
     }
 }
 


### PR DESCRIPTION
ref #48 

This PR introduces logic to support DA throttling in the builder by forwarding `miner_` requests to the builder, following the same convention in the `EthApiServer` implementation. 

Feel free to let me know any feedback on the approach and if you have a preference on how to extend or amend the current test harness to best test this feature.