### PR TITLE
Enable boost-sync by default

### DIFF
--- a/src/integration/service_rb.rs
+++ b/src/integration/service_rb.rs
@@ -53,8 +53,7 @@ impl Service for RollupBoostConfig {
             .arg(Arg::Port {
                 name: "rpc".into(),
                 preferred: 8112,
-            })
-            .arg("--boost-sync");
+            });
 
         cmd
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,9 +42,9 @@ struct Args {
     #[clap(flatten)]
     l2_client: L2ClientArgs,
 
-    /// Use the proposer to sync the builder node
+    /// Disable using the proposer to sync the builder node
     #[arg(long, env, default_value = "false")]
-    boost_sync: bool,
+    no_boost_sync: bool,
 
     /// Host to run the server on
     #[arg(long, env, default_value = "0.0.0.0")]
@@ -162,7 +162,13 @@ async fn main() -> eyre::Result<()> {
         builder_args.builder_timeout,
     )?;
 
-    let rollup_boost = RollupBoostServer::new(l2_client, builder_client, args.boost_sync, metrics);
+    let boost_sync_enabled = !args.no_boost_sync;
+    if boost_sync_enabled {
+        info!("Boost sync enabled");
+    }
+
+    let rollup_boost =
+        RollupBoostServer::new(l2_client, builder_client, boost_sync_enabled, metrics);
 
     let module: RpcModule<()> = rollup_boost.try_into()?;
 


### PR DESCRIPTION
This PR enables boost sync by default since for lower block times (<300ms) it is a requirement to receive the latest block as fast as possible. The PR changes the flag `--boost-sync` that enabled boost sync with a new flag `--no-boost-sync` which disables it if not required.
