### PR TITLE
Stop integration if service stopped during init

### DIFF
--- a/src/integration/service_rb.rs
+++ b/src/integration/service_rb.rs
@@ -1,9 +1,6 @@
-use crate::integration::{poll_logs, Arg, IntegrationError, Service, ServiceCommand};
+use crate::integration::{Arg, IntegrationError, Service, ServiceCommand, ServiceInstance};
 use futures_util::Future;
-use std::{
-    path::{Path, PathBuf},
-    time::Duration,
-};
+use std::{path::PathBuf, time::Duration};
 
 #[derive(Default)]
 pub struct RollupBoostConfig {
@@ -59,16 +56,10 @@ impl Service for RollupBoostConfig {
         cmd
     }
 
-    #[allow(clippy::manual_async_fn)]
-    fn ready(&self, log_path: &Path) -> impl Future<Output = Result<(), IntegrationError>> + Send {
-        async move {
-            poll_logs(
-                log_path,
-                "Starting server on",
-                Duration::from_millis(100),
-                Duration::from_secs(60),
-            )
-            .await
-        }
+    fn ready(
+        &self,
+        service: &mut ServiceInstance,
+    ) -> impl Future<Output = Result<(), IntegrationError>> + Send {
+        async move { service.wait_for_log("Starting server on", Duration::from_secs(5)) }
     }
 }

--- a/src/integration/service_reth.rs
+++ b/src/integration/service_reth.rs
@@ -1,9 +1,6 @@
-use crate::integration::{poll_logs, Arg, IntegrationError, Service, ServiceCommand};
+use crate::integration::{Arg, IntegrationError, Service, ServiceCommand, ServiceInstance};
 use futures_util::Future;
-use std::{
-    path::{Path, PathBuf},
-    time::Duration,
-};
+use std::{path::PathBuf, time::Duration};
 
 #[derive(Default)]
 pub struct RethConfig {
@@ -63,16 +60,10 @@ impl Service for RethConfig {
             .arg("--ipcdisable")
     }
 
-    #[allow(clippy::manual_async_fn)]
-    fn ready(&self, log_path: &Path) -> impl Future<Output = Result<(), IntegrationError>> + Send {
-        async move {
-            poll_logs(
-                log_path,
-                "Starting consensus engine",
-                Duration::from_millis(100),
-                Duration::from_secs(60),
-            )
-            .await
-        }
+    fn ready(
+        &self,
+        service: &mut ServiceInstance,
+    ) -> impl Future<Output = Result<(), IntegrationError>> + Send {
+        async move { service.wait_for_log("Starting consensus", Duration::from_secs(5)) }
     }
 }


### PR DESCRIPTION
Stop the integration test if a service exists during initialization. Before, we would wait for the timeout of the poll_logs method but that can be slow and it does not give you useful information to know why the process did not start.