### PR TITLE
fix: Remove `MULTIPLEX_METHODS` that are already included in `FORWARD_REQUESTS`

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -11,12 +11,7 @@ use std::{future::Future, pin::Pin};
 use tower::{Layer, Service};
 use tracing::{debug, error, info};
 
-const MULTIPLEX_METHODS: [&str; 4] = [
-    "engine_",
-    "eth_sendRawTransactionConditional",
-    "eth_sendRawTransaction",
-    "miner_",
-];
+const MULTIPLEX_METHODS: [&str; 1] = ["engine_"];
 const FORWARD_REQUESTS: [&str; 6] = [
     "eth_sendRawTransaction",
     "eth_sendRawTransactionConditional",


### PR DESCRIPTION
This PR updates `MULTIPLEX_METHODS` by removing `eth_sendRawTransactionConditional`, `eth_sendRawTransaction`, and `miner_ methods` in favor of `FORWARD_REQUESTS`. This ensures that these methods are forwarded directly rather than being handled by the multiplex logic.

As previously mentioned, since forwarded methods are sent over auth RPC, client implementations must expose these methods through their auth RPC endpoint. Alternatively, we could reintroduce logic to forward requests to JSON-RPC endpoints to ensure non-multiplexed requests are routed correctly.