### PR TITLE
Cleanup Integration + builder down integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5247,6 +5247,7 @@ dependencies = [
  "thiserror 1.0.65",
  "time",
  "tokio",
+ "tokio-util",
  "tower 0.4.13",
  "tracing",
  "tracing-opentelemetry",
@@ -6176,9 +6177,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ lazy_static = "1.5.0"
 anyhow = "1.0"
 assert_cmd = "2.0.10"
 predicates = "3.1.2"
+tokio-util = { version = "0.7.13" }
 
 [features]
 integration = []

--- a/src/integration/integration_test.rs
+++ b/src/integration/integration_test.rs
@@ -6,7 +6,7 @@ mod tests {
     #[tokio::test]
     async fn test_integration_simple() -> eyre::Result<()> {
         let harness = RollupBoostTestHarness::new("test_integration_simple").await?;
-        let mut block_generator = harness.get_block_generator().await;
+        let mut block_generator = harness.get_block_generator().await?;
 
         for _ in 0..5 {
             let (_block, block_creator) = block_generator.generate_block(false).await?;
@@ -24,8 +24,7 @@ mod tests {
     #[tokio::test]
     async fn test_integration_no_tx_pool() -> eyre::Result<()> {
         let harness = RollupBoostTestHarness::new("test_integration_no_tx_pool").await?;
-
-        let mut block_generator = harness.get_block_generator().await;
+        let mut block_generator = harness.get_block_generator().await?;
 
         // start creating 5 empty blocks which are processed by the L2 builder
         for _ in 0..5 {
@@ -49,7 +48,7 @@ mod tests {
     #[tokio::test]
     async fn test_integration_dry_run() -> eyre::Result<()> {
         let harness = RollupBoostTestHarness::new("test_integration_dry_run").await?;
-        let mut block_generator = harness.get_block_generator().await;
+        let mut block_generator = harness.get_block_generator().await?;
 
         // start creating 5 empty blocks which are processed by the builder
         for _ in 0..5 {
@@ -89,6 +88,52 @@ mod tests {
                 block_creator.is_builder(),
                 "Block creator should be the builder"
             );
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_integration_remote_builder_down() -> eyre::Result<()> {
+        let mut harness =
+            RollupBoostTestHarness::new("test_integration_remote_builder_down").await?;
+        let mut block_generator = harness.get_block_generator().await?;
+
+        for _ in 0..3 {
+            let (_block, block_creator) = block_generator.generate_block(false).await?;
+            assert!(
+                block_creator.is_builder(),
+                "Block creator should be the builder"
+            );
+
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+
+        // stop the builder
+        let builder_service = harness._framework.get_mut_service("builder")?;
+        builder_service.stop()?;
+
+        // create 3 new blocks that are processed by the l2 builder
+        for _ in 0..3 {
+            let (_block, block_creator) = block_generator.generate_block(false).await?;
+            assert!(block_creator.is_l2(), "Block creator should be l2");
+        }
+
+        // start the builder again
+        builder_service.start_and_ready()?;
+
+        // the next block is computed by the l2 builder because the builder is not synced with the previous 3 blocks
+        // But, once the builder receives the FCU request from rollup-boost, it will sync up the blocks with the
+        // L2 block builder and be ready again.
+        let (_block, block_creator) = block_generator.generate_block(false).await?;
+        assert!(block_creator.is_l2(), "Block creator should be l2");
+
+        // Note: We might add some sleep here if the builder is not synced in time. I have not seen this happen yet.
+
+        // create 3 new blocks that are processed by the l2 builder because the builder is not synced with the previous 3 blocks
+        for _ in 0..3 {
+            let (_block, block_creator) = block_generator.generate_block(false).await?;
+            assert!(block_creator.is_builder(), "Block creator should be l2");
         }
 
         Ok(())

--- a/src/integration/service_rb.rs
+++ b/src/integration/service_rb.rs
@@ -1,5 +1,4 @@
-use crate::integration::{Arg, IntegrationError, Service, ServiceCommand, ServiceInstance};
-use futures_util::Future;
+use crate::integration::{Arg, ReadyParams, Service, ServiceCommand};
 use std::{path::PathBuf, time::Duration};
 
 #[derive(Default)]
@@ -60,10 +59,10 @@ impl Service for RollupBoostConfig {
         cmd
     }
 
-    fn ready(
-        &self,
-        service: &mut ServiceInstance,
-    ) -> impl Future<Output = Result<(), IntegrationError>> + Send {
-        async move { service.wait_for_log("Starting server on", Duration::from_secs(5)) }
+    fn ready(&self) -> ReadyParams {
+        ReadyParams {
+            log_pattern: "Starting server on".to_string(),
+            duration: Duration::from_secs(5),
+        }
     }
 }


### PR DESCRIPTION
This PR does several things:
- It cleans up a little bit of the integration framework (introduces functions to start/stop/restart the services).
- It connects through P2P the EL and Builder instances of the integration test harness.
- It introduces a new test that checks that the builder can be stopped, rollup-boost does not fail and once the builder gets restarted the system goes back to normal.