### PR TITLE
Add a proxy in between Rollup-boost + Rbuilder and simulate latencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5230,6 +5230,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "anyhow",
  "assert_cmd",
+ "bytes",
  "clap",
  "dotenv",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ assert_cmd = "2.0.10"
 predicates = "3.1.2"
 tokio-util = { version = "0.7.13" }
 nix = "0.15.0"
+bytes = "1.2"
 
 [features]
 integration = []

--- a/src/integration/integration_test.rs
+++ b/src/integration/integration_test.rs
@@ -1,11 +1,17 @@
 #[cfg(test)]
 mod tests {
+    use serde_json::Value;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
     use crate::debug_api::SetDryRunRequestAction;
-    use crate::integration::RollupBoostTestHarness;
+    use crate::integration::RollupBoostTestHarnessBuilder;
 
     #[tokio::test]
     async fn test_integration_simple() -> eyre::Result<()> {
-        let harness = RollupBoostTestHarness::new("test_integration_simple").await?;
+        let harness = RollupBoostTestHarnessBuilder::new("test_integration_simple")
+            .build()
+            .await?;
         let mut block_generator = harness.get_block_generator().await?;
 
         for _ in 0..5 {
@@ -23,7 +29,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_integration_no_tx_pool() -> eyre::Result<()> {
-        let harness = RollupBoostTestHarness::new("test_integration_no_tx_pool").await?;
+        let harness = RollupBoostTestHarnessBuilder::new("test_integration_no_tx_pool")
+            .build()
+            .await?;
         let mut block_generator = harness.get_block_generator().await?;
 
         // start creating 5 empty blocks which are processed by the L2 builder
@@ -47,7 +55,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_integration_dry_run() -> eyre::Result<()> {
-        let harness = RollupBoostTestHarness::new("test_integration_dry_run").await?;
+        let harness = RollupBoostTestHarnessBuilder::new("test_integration_dry_run")
+            .build()
+            .await?;
         let mut block_generator = harness.get_block_generator().await?;
 
         // start creating 5 empty blocks which are processed by the builder
@@ -96,7 +106,9 @@ mod tests {
     #[tokio::test]
     async fn test_integration_remote_builder_down() -> eyre::Result<()> {
         let mut harness =
-            RollupBoostTestHarness::new("test_integration_remote_builder_down").await?;
+            RollupBoostTestHarnessBuilder::new("test_integration_remote_builder_down")
+                .build()
+                .await?;
         let mut block_generator = harness.get_block_generator().await?;
 
         for _ in 0..3 {
@@ -134,6 +146,51 @@ mod tests {
         for _ in 0..3 {
             let (_block, block_creator) = block_generator.generate_block(false).await?;
             assert!(block_creator.is_builder(), "Block creator should be l2");
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_integration_builder_full_delay() -> eyre::Result<()> {
+        // Create a dynamic handler that delays all the calls by 2 seconds
+        let delay = Arc::new(Mutex::new(Duration::from_secs(0)));
+
+        let delay_for_handler = delay.clone();
+        let handler = Box::new(move |_method: &str, _params: Value, _result: Value| {
+            let delay = delay_for_handler.lock().unwrap();
+            // sleep the amount of time specified in the delay
+            std::thread::sleep(*delay);
+            Ok(Value::Null)
+        });
+
+        // This integration test checks that if the builder has a general delay in processing ANY of the requests,
+        // rollup-boost does not stop building blocks.
+        let harness = RollupBoostTestHarnessBuilder::new("test_integration_proxy")
+            .proxy_handler(handler)
+            .build()
+            .await?;
+
+        let mut block_generator = harness.get_block_generator().await?;
+
+        // create 3 blocks that are processed by the builder
+        for _ in 0..3 {
+            let (_block, block_creator) = block_generator.generate_block(false).await?;
+            assert!(
+                block_creator.is_builder(),
+                "Block creator should be the builder"
+            );
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        }
+
+        // add the delay
+        *delay.lock().unwrap() = Duration::from_secs(2);
+
+        // create 3 blocks that are processed by the builder
+        for _ in 0..3 {
+            let (_block, block_creator) = block_generator.generate_block(false).await?;
+            assert!(block_creator.is_l2(), "Block creator should be the builder");
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
         }
 
         Ok(())

--- a/src/integration/mod.rs
+++ b/src/integration/mod.rs
@@ -246,6 +246,14 @@ impl ServiceInstance {
         format!("http://localhost:{}", self.get_port(name))
     }
 
+    pub fn get_logs(&self) -> Result<String, IntegrationError> {
+        let mut file = File::open(&self.log_path).map_err(|_| IntegrationError::LogError)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)
+            .map_err(|_| IntegrationError::LogError)?;
+        Ok(contents)
+    }
+
     pub fn wait_for_log(
         &mut self,
         pattern: &str,
@@ -272,10 +280,7 @@ impl ServiceInstance {
                 return Err(IntegrationError::SpawnError);
             }
 
-            let mut file = File::open(&self.log_path).map_err(|_| IntegrationError::LogError)?;
-            let mut contents = String::new();
-            file.read_to_string(&mut contents)
-                .map_err(|_| IntegrationError::LogError)?;
+            let mut contents = self.get_logs()?;
 
             // Since we share the same log file for different executions of the same service during the lifespan
             // of the test, we need to filter the logs and only consider the logs of the current execution.

--- a/src/integration/proxy.rs
+++ b/src/integration/proxy.rs
@@ -1,0 +1,122 @@
+use bytes::Bytes;
+use http_body_util::{combinators::BoxBody, BodyExt, Full};
+use hyper::client::conn::http1::Builder;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Request, Response};
+use hyper_util::rt::TokioIo;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::net::{TcpListener, TcpStream};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct JsonRpcRequest {
+    jsonrpc: String,
+    method: String,
+    params: Value,
+    id: Value,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct JsonRpcResponse {
+    jsonrpc: String,
+    #[serde(default)]
+    result: Option<Value>,
+    #[serde(default)]
+    error: Option<JsonRpcError>,
+    id: Value,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct JsonRpcError {
+    code: i32,
+    message: String,
+    data: Option<Value>,
+}
+
+pub type DynHandlerFn =
+    Box<dyn Fn(&str, Value, Value) -> Result<Value, JsonRpcError> + Send + Sync>;
+
+// Structure to hold the target address that we'll pass to the proxy function
+#[derive(Clone)]
+struct ProxyConfig {
+    target_addr: SocketAddr,
+    handler: Arc<DynHandlerFn>,
+}
+
+async fn proxy(
+    config: ProxyConfig,
+    req: Request<hyper::body::Incoming>,
+) -> Result<Response<BoxBody<Bytes, hyper::Error>>, Box<dyn std::error::Error + Send + Sync>> {
+    let (parts, body) = req.into_parts();
+    let bytes = body.collect().await?.to_bytes();
+
+    let json_rpc_request = serde_json::from_slice::<JsonRpcRequest>(&bytes).unwrap();
+    let req = Request::from_parts(parts, Full::new(bytes));
+
+    let stream = TcpStream::connect(config.target_addr).await?;
+    let io = TokioIo::new(stream);
+
+    let (mut sender, conn) = Builder::new()
+        .preserve_header_case(true)
+        .title_case_headers(true)
+        .handshake(io)
+        .await?;
+
+    tokio::task::spawn(async move {
+        if let Err(err) = conn.await {
+            println!("Connection failed: {:?}", err);
+        }
+    });
+
+    let resp = sender.send_request(req).await?;
+
+    let (parts, body) = resp.into_parts();
+    let bytes = body.collect().await?.to_bytes();
+
+    let json_rpc_response = serde_json::from_slice::<JsonRpcResponse>(&bytes).unwrap();
+    if let Some(result) = json_rpc_response.result {
+        let _ = (config.handler)(&json_rpc_request.method, json_rpc_request.params, result);
+    }
+
+    let resp = Response::from_parts(parts, Full::new(bytes).map_err(|_| unreachable!()));
+    Ok(resp.map(|b| b.boxed()))
+}
+
+pub async fn start_proxy_server(
+    handler: DynHandlerFn,
+    listen_port: u16,
+    target_port: u16,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let listen_addr = SocketAddr::from(([127, 0, 0, 1], listen_port));
+    let target_addr = SocketAddr::from(([127, 0, 0, 1], target_port));
+
+    let config = ProxyConfig {
+        target_addr,
+        handler: Arc::new(handler),
+    };
+    let listener = TcpListener::bind(listen_addr).await?;
+
+    tokio::spawn(async move {
+        loop {
+            let (stream, _) = listener.accept().await.unwrap();
+            let io = TokioIo::new(stream);
+            let config = config.clone();
+
+            tokio::task::spawn(async move {
+                if let Err(err) = http1::Builder::new()
+                    .preserve_header_case(true)
+                    .title_case_headers(true)
+                    .serve_connection(io, service_fn(move |req| proxy(config.clone(), req)))
+                    .await
+                {
+                    println!("Failed to serve connection: {:?}", err);
+                }
+            });
+        }
+    });
+
+    Ok(())
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -476,8 +476,6 @@ impl RollupBoostServer {
             let block_hash = ExecutionPayload::from(payload.clone().execution_payload).block_hash();
             info!(message = "received payload from builder", "local_payload_id" = %payload_id, "external_payload_id" = %external_payload_id, "block_hash" = %block_hash);
 
-            println!("A");
-
             // Send the payload to the local execution engine with engine_newPayload to validate the block from the builder.
             // Otherwise, we do not want to risk the network to a halt since op-node will not be able to propose the block.
             // If validation fails, return the local block since that one has already been validated.
@@ -485,17 +483,10 @@ impl RollupBoostServer {
                 metrics.new_payload_count.increment(1);
             }
 
-            println!("B");
-
             let payload_status = self.l2_client.auth_client.new_payload_v3(payload.execution_payload.clone(), vec![], payload.parent_beacon_block_root).await.map_err(|e| {
-                println!("D");
-
                 error!(message = "error calling new_payload_v3 to validate builder payload", "url" = ?self.l2_client.auth_rpc, "error" = %e, "local_payload_id" = %payload_id, "external_payload_id" = %external_payload_id);
                 e
             })?;
-
-            println!("C");
-
             if let Some(mut s) = span {
                 s.end();
             };
@@ -506,10 +497,7 @@ impl RollupBoostServer {
                 }
             };
 
-            println!("E");
-
             if payload_status.is_invalid() {
-                println!("F");
                 error!(message = "builder payload was not valid", "url" = ?builder.auth_rpc, "payload_status" = %payload_status.status, "local_payload_id" = %payload_id, "external_payload_id" = %external_payload_id);
                 Err(ClientError::Call(ErrorObject::owned(
                     INVALID_REQUEST_CODE,

--- a/src/server.rs
+++ b/src/server.rs
@@ -476,16 +476,26 @@ impl RollupBoostServer {
             let block_hash = ExecutionPayload::from(payload.clone().execution_payload).block_hash();
             info!(message = "received payload from builder", "local_payload_id" = %payload_id, "external_payload_id" = %external_payload_id, "block_hash" = %block_hash);
 
+            println!("A");
+
             // Send the payload to the local execution engine with engine_newPayload to validate the block from the builder.
             // Otherwise, we do not want to risk the network to a halt since op-node will not be able to propose the block.
             // If validation fails, return the local block since that one has already been validated.
             if let Some(metrics) = &self.metrics {
                 metrics.new_payload_count.increment(1);
             }
+
+            println!("B");
+
             let payload_status = self.l2_client.auth_client.new_payload_v3(payload.execution_payload.clone(), vec![], payload.parent_beacon_block_root).await.map_err(|e| {
+                println!("D");
+
                 error!(message = "error calling new_payload_v3 to validate builder payload", "url" = ?self.l2_client.auth_rpc, "error" = %e, "local_payload_id" = %payload_id, "external_payload_id" = %external_payload_id);
                 e
             })?;
+
+            println!("C");
+
             if let Some(mut s) = span {
                 s.end();
             };
@@ -495,7 +505,11 @@ impl RollupBoostServer {
                     parent.end();
                 }
             };
+
+            println!("E");
+
             if payload_status.is_invalid() {
+                println!("F");
                 error!(message = "builder payload was not valid", "url" = ?builder.auth_rpc, "payload_status" = %payload_status.status, "local_payload_id" = %payload_id, "external_payload_id" = %external_payload_id);
                 Err(ClientError::Call(ErrorObject::owned(
                     INVALID_REQUEST_CODE,


### PR DESCRIPTION
This PR adds a proxy in between Rollup-boost and the builder and adds two tests:
- One that simulates latency between Rollup-boost and the builder.
- One that changes the state root from the payload returned by the builder. Rollup-boost has to detect it and return the L2 block.