### PR TITLE
feat: add TLS support in Proxy client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,28 +633,26 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.10.0"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd82dba44d209fddb11c190e0a94b78651f95299598e472215667417a03ff1d"
+checksum = "4c2b7ddaa2c56a367ad27a094ad8ef4faacf8a617c2575acb2ba88949df999ca"
 dependencies = [
  "aws-lc-sys",
- "mirai-annotations",
  "paste",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.22.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7a4168111d7eb622a31b214057b8509c0a7e1794f44c546d742330dc793972"
+checksum = "54ac4f13dad353b209b34cbec082338202cbc01c8f00336b55c750c13ac91f8f"
 dependencies = [
  "bindgen 0.69.5",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "libc",
  "paste",
 ]
 
@@ -1128,6 +1126,21 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "ctor"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d960ecacd0a1bf55e73144b72de745e7bf275c7952c50e36e8af0a0cb7ab1f"
+dependencies = [
+ "ctor-proc-macro",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c426d2ba3e525b39c1f0a9ba41b9fe61878dee11fa4e4a76b6ab440f46c5db5d"
 
 [[package]]
 name = "darling"
@@ -2543,12 +2556,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mirai-annotations"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
-
-[[package]]
 name = "native-tls"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3498,6 +3505,7 @@ dependencies = [
  "assert_cmd",
  "bytes",
  "clap",
+ "ctor",
  "dotenv",
  "eyre",
  "futures",
@@ -3506,6 +3514,7 @@ dependencies = [
  "http-body 0.4.6",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "jsonrpsee",
  "lazy_static",
@@ -3527,6 +3536,7 @@ dependencies = [
  "predicates",
  "reqwest",
  "reth-rpc-layer",
+ "rustls",
  "serde",
  "serde_json",
  "thiserror 1.0.65",
@@ -3635,9 +3645,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.16"
+version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ http-body = "0.4.5"
 http-body-util = "0.1.2"
 hyper = { version = "1.4.1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
+hyper-rustls = { version = "0.27.0", features = ["ring"] }
+rustls = {version = "0.23.23", features = ["ring"] }
 serde_json = "1.0.96"
 opentelemetry = { version = "0.26.0", features = ["trace"] }
 opentelemetry-http = "0.26.0"
@@ -60,6 +62,7 @@ tokio-util = { version = "0.7.13" }
 nix = "0.15.0"
 bytes = "1.2"
 reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth.git", rev = "e022b6fd92a33cd44e3ae51ee2fc2ecc0f773222" }
+ctor = "0.3.5"
 
 [features]
 integration = []

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,6 +112,9 @@ enum DebugCommands {
 async fn main() -> eyre::Result<()> {
     // Load .env file
     dotenv().ok();
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install TLS ring CryptoProvider");
     let args: Args = Args::parse();
 
     // Handle commands if present


### PR DESCRIPTION
Adds TLS compatibility to client in the proxy. 

This is important as the JWT can be sniffed out of the headers in non `https` connections with the builder. These changes are backwards compatible with `http`, but now allow `rollup-boost` to connect to the builder over the auth API in the proxy through TLS.