### PR TITLE
chore: argument to set execution 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,10 @@ struct Args {
     /// Debug server port
     #[arg(long, env, default_value = "5555")]
     debug_server_port: u16,
+
+    /// Execution mode to start rollup boost with
+    #[arg(long, env, default_value = "enabled")]
+    execution_mode: ExecutionMode,
 }
 
 #[derive(Subcommand, Debug)]
@@ -240,6 +244,7 @@ async fn main() -> eyre::Result<()> {
         builder_client,
         boost_sync_enabled,
         metrics.clone(),
+        args.execution_mode,
     );
 
     // Spawn the debug server

--- a/src/server.rs
+++ b/src/server.rs
@@ -730,7 +730,7 @@ mod tests {
             .unwrap();
 
             let rollup_boost_client =
-                RollupBoostServer::new(l2_client, builder_client, boost_sync, None);
+                RollupBoostServer::new(l2_client, builder_client, boost_sync, None, ExecutionMode::Enabled);
 
             let module: RpcModule<()> = rollup_boost_client.try_into().unwrap();
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -142,6 +142,7 @@ impl RollupBoostServer {
         builder_client: ExecutionClient,
         boost_sync: bool,
         metrics: Option<Arc<ServerMetrics>>,
+        initial_execution_mode: ExecutionMode,
     ) -> Self {
         Self {
             l2_client,
@@ -149,7 +150,7 @@ impl RollupBoostServer {
             boost_sync,
             metrics,
             payload_trace_context: Arc::new(PayloadTraceContext::new()),
-            execution_mode: Arc::new(Mutex::new(ExecutionMode::Enabled)),
+            execution_mode: Arc::new(Mutex::new(initial_execution_mode)),
         }
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -729,8 +729,13 @@ mod tests {
             )
             .unwrap();
 
-            let rollup_boost_client =
-                RollupBoostServer::new(l2_client, builder_client, boost_sync, None, ExecutionMode::Enabled);
+            let rollup_boost_client = RollupBoostServer::new(
+                l2_client,
+                builder_client,
+                boost_sync,
+                None,
+                ExecutionMode::Enabled,
+            );
 
             let module: RpcModule<()> = rollup_boost_client.try_into().unwrap();
 


### PR DESCRIPTION
### Description
Add a CLI argument `--execution-mode` to allow users to set the execution mode on startup. Currently when deploying a new sequencer, we:

1. Start a new node
2. Restore a snapshot
3. Sync the node top tip
4. Do a handover from the old sequencer to the new

In this flow, it would be ideal to start rollup boost on the new node with exeuciton-mode=disabled, then on the handover (step 4) set the execution mode to enabled.