### PR TITLE
Remove idle tcp connections

### DIFF
--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::server::PayloadSource;
 use alloy_rpc_types_engine::JwtSecret;
 use http::Uri;
@@ -32,7 +34,10 @@ impl HttpClient {
             .enable_http2()
             .build();
 
-        let client = Client::builder(TokioExecutor::new()).build(connector);
+        let client = Client::builder(TokioExecutor::new())
+            .pool_timer(hyper_util::rt::TokioTimer::new())
+            .pool_idle_timeout(Duration::from_millis(2_500))
+            .build(connector);
 
         let client = ServiceBuilder::new()
             .layer(DecompressionLayer::new())

--- a/src/client/rpc.rs
+++ b/src/client/rpc.rs
@@ -110,6 +110,7 @@ impl RpcClient {
         let auth_client = HttpClientBuilder::new()
             .set_http_middleware(tower::ServiceBuilder::new().layer(auth_layer))
             .request_timeout(Duration::from_millis(timeout))
+            .set_tcp_no_delay(true)
             .build(auth_rpc.to_string())?;
 
         Ok(Self {


### PR DESCRIPTION
Resolves https://github.com/flashbots/rollup-boost/issues/126 for the proxy client. However there isn't an explicit way to configure the timeout on the json rpc see client library.