### PR TITLE
feat: expose rollup-boost library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3466,6 +3466,7 @@ dependencies = [
 name = "rollup-boost"
 version = "0.1.0"
 dependencies = [
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -3483,6 +3484,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "jsonrpsee",
+ "lazy_static",
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-util",
@@ -3500,6 +3502,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.12",
+ "time",
  "tokio",
  "tokio-util",
  "tower 0.4.13",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,7 +670,7 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bbe221bbf523b625a4dd8585c7f38166e31167ec2ca98051dbcb4c3b6e825d2"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "cc",
  "cmake",
  "dunce",
@@ -778,24 +778,6 @@ dependencies = [
  "shlex",
  "syn 2.0.100",
  "which",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
-dependencies = [
- "bitflags 2.9.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.100",
 ]
 
 [[package]]
@@ -1449,15 +1431,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,21 +1584,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,16 +1676,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-dependencies = [
- "gloo-timers",
- "send_wrapper",
-]
-
-[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,52 +1753,6 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
-name = "gloo-net"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06f627b1a58ca3d42b45d6104bf1e1a03799df472df00988b6ba21accc10580"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-sink",
- "gloo-utils",
- "http",
- "js-sys",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "gloo-utils"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
-]
 
 [[package]]
 name = "group"
@@ -2039,22 +1941,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -2402,41 +2288,13 @@ version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "834af00800e962dee8f7bfc0f60601de215e73e78e5497d733a2919da837d3c8"
 dependencies = [
- "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-http-client",
  "jsonrpsee-proc-macros",
  "jsonrpsee-server",
  "jsonrpsee-types",
- "jsonrpsee-wasm-client",
- "jsonrpsee-ws-client",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "jsonrpsee-client-transport"
-version = "0.24.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def0fd41e2f53118bd1620478d12305b2c75feef57ea1f93ef70568c98081b7e"
-dependencies = [
- "base64",
- "futures-channel",
- "futures-util",
- "gloo-net",
- "http",
- "jsonrpsee-core",
- "pin-project",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "soketto",
- "thiserror 1.0.69",
- "tokio",
- "tokio-rustls",
- "tokio-util",
- "tracing",
- "url",
 ]
 
 [[package]]
@@ -2447,23 +2305,19 @@ checksum = "76637f6294b04e747d68e69336ef839a3493ca62b35bf488ead525f7da75c5bb"
 dependencies = [
  "async-trait",
  "bytes",
- "futures-timer",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
  "jsonrpsee-types",
  "parking_lot",
- "pin-project",
  "rand",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
- "tokio-stream",
  "tracing",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -2541,30 +2395,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "jsonrpsee-wasm-client"
-version = "0.24.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e41af42ca39657313748174d02766e5287d3a57356f16756dbd8065b933977"
-dependencies = [
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
-]
-
-[[package]]
-name = "jsonrpsee-ws-client"
-version = "0.24.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f4f3642a292f5b76d8a16af5c88c16a0860f2ccc778104e5c848b28183d9538"
-dependencies = [
- "http",
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
- "jsonrpsee-types",
- "url",
 ]
 
 [[package]]
@@ -2650,17 +2480,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
-name = "libproc"
-version = "0.14.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78a09b56be5adbcad5aa1197371688dc6bb249a26da3bca2011ee2fb987ebfb"
-dependencies = [
- "bindgen 0.70.1",
- "errno",
- "libc",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2708,15 +2527,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mach2"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "macro-string"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2759,18 +2569,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "metrics-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3dbdd96ed57d565ec744cba02862d707acf373c5772d152abae6ec5c4e24f6c"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "syn 2.0.100",
-]
-
-[[package]]
 name = "metrics-exporter-prometheus"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2789,22 +2587,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "metrics-process"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a82c8add4382f29a122fa64fff1891453ed0f6b2867d971e7d60cb8dfa322ff"
-dependencies = [
- "libc",
- "libproc",
- "mach2",
- "metrics",
- "once_cell",
- "procfs",
- "rlimit",
- "windows",
 ]
 
 [[package]]
@@ -2886,23 +2668,6 @@ dependencies = [
  "tagptr",
  "thiserror 1.0.69",
  "uuid",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 2.11.1",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -3043,34 +2808,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "op-alloy-rpc-jsonrpsee"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ad24013146aecff6fb5cc5f3ed2273830b79a1b12c1bad0bdd76e2f5fe43c6"
-dependencies = [
- "alloy-primitives",
- "jsonrpsee",
-]
-
-[[package]]
-name = "op-alloy-rpc-types"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01f7baa1b04d0bf3816868dd5f4f3e411971a1c95b4a656d3c5c583bdb75ea5"
-dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-network-primitives",
- "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "derive_more 1.0.0",
- "op-alloy-consensus",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "op-alloy-rpc-types-engine"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3090,48 +2827,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.71"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
-dependencies = [
- "bitflags 2.9.0",
- "cfg-if 1.0.0",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.106"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -3479,28 +3178,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "procfs"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
-dependencies = [
- "bitflags 2.9.0",
- "hex",
- "procfs-core",
- "rustix 0.38.44",
-]
-
-[[package]]
-name = "procfs-core"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
-dependencies = [
- "bitflags 2.9.0",
- "hex",
-]
-
-[[package]]
 name = "proptest"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3708,34 +3385,26 @@ checksum = "989e327e510263980e231de548a33e63d34962d29ae61b467389a1a09627a254"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
- "tokio-native-tls",
  "tower 0.5.2",
  "tower-service",
  "url",
@@ -3784,15 +3453,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rlimit"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7043b63bd0cd1aaa628e476b80e6d4023a3b50eb32789f2728908107bd0c793a"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3806,7 +3466,6 @@ dependencies = [
 name = "rollup-boost"
 version = "0.1.0"
 dependencies = [
- "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -3817,41 +3476,30 @@ dependencies = [
  "ctor",
  "dotenv",
  "eyre",
- "flate2",
  "futures",
- "futures-util",
  "http",
- "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
  "hyper-util",
  "jsonrpsee",
- "lazy_static",
  "metrics",
- "metrics-derive",
  "metrics-exporter-prometheus",
- "metrics-process",
  "metrics-util",
  "moka",
  "nix",
- "op-alloy-rpc-jsonrpsee",
- "op-alloy-rpc-types",
  "op-alloy-rpc-types-engine",
  "opentelemetry",
- "opentelemetry-http",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "parking_lot",
  "paste",
  "predicates",
- "reqwest",
  "reth-rpc-layer",
  "rustls",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
- "time",
  "tokio",
  "tokio-util",
  "tower 0.4.13",
@@ -4196,12 +3844,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "send_wrapper"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
-
-[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4540,27 +4182,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.9.0",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4727,16 +4348,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -5116,12 +4727,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,8 @@ edition = "2024"
 
 [dependencies]
 op-alloy-rpc-types-engine = "0.11.1"
-op-alloy-rpc-types = "0.11.1"
-op-alloy-rpc-jsonrpsee = { version = "0.11.1", features = ["client"] }
 alloy-rpc-types-engine = "0.12.5"
-alloy-rpc-types-eth = "0.12.5"
 alloy-primitives = { version = "0.8.10", features = ["rand"] }
-alloy-eips = { version = "0.12.5", features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1.4"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter", "json"] }
@@ -19,12 +15,10 @@ thiserror = "2.0.12"
 clap = { version = "4", features = ["derive", "env"] }
 jsonrpsee = { version = "0.24", features = ["server", "http-client", "macros"] }
 moka = { version = "0.12.10", features = ["sync"] }
-reqwest = "0.12.5"
 http = "1.1.0"
 dotenv = "0.15.0"
 tower = "0.4.13"
 tower-http = { version = "0.5.2", features = ["decompression-full"] }
-http-body = "1.0.1"
 http-body-util = "0.1.2"
 hyper = { version = "1.4.1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
@@ -32,7 +26,6 @@ hyper-rustls = { version = "0.27.0", features = ["ring"] }
 rustls = { version = "0.23.23", features = ["ring"] }
 serde_json = "1.0.96"
 opentelemetry = { version = "0.28.0", features = ["trace"] }
-opentelemetry-http = "0.28.0"
 opentelemetry-otlp = { version = "0.28.0", features = [
     "http-proto",
     "http-json",
@@ -42,23 +35,18 @@ opentelemetry-otlp = { version = "0.28.0", features = [
 ] }
 opentelemetry_sdk = { version = "0.28.0", features = ["rt-tokio"] }
 tracing-opentelemetry = "0.29.0"
-flate2 = "1.0.35"
 futures = "0.3.31"
-metrics-derive = "0.1"
 metrics = "0.24.0"
 metrics-exporter-prometheus = "0.16.0"
-metrics-process = "2.3.1"
 metrics-util = "0.19.0"
 eyre = "0.6.12"
 paste = "1.0.15"
 
 # dev dependencies for integration tests
-time = { version = "0.3.36", features = ["macros", "formatting", "parsing"] }
-futures-util = "0.3.31"
-lazy_static = "1.5.0"
 parking_lot = "0.12.3"
 
 [dev-dependencies]
+alloy-rpc-types-eth = "0.12.5"
 anyhow = "1.0"
 assert_cmd = "2.0.10"
 predicates = "3.1.2"
@@ -70,3 +58,10 @@ ctor = "0.4.1"
 
 [features]
 integration = []
+
+[[bin]]
+name = "rollup-boost"
+path = "src/bin/main.rs"
+
+[lib]
+path = "src/lib.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 op-alloy-rpc-types-engine = "0.11.1"
 alloy-rpc-types-engine = "0.12.5"
+alloy-eips = { version = "0.12.5", features = ["serde"], optional = true }
 alloy-primitives = { version = "0.8.10", features = ["rand"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1.4"
@@ -44,6 +45,8 @@ paste = "1.0.15"
 
 # dev dependencies for integration tests
 parking_lot = "0.12.3"
+time = { version = "0.3.36", features = ["macros", "formatting", "parsing"], optional = true }
+lazy_static = {version = "1.5.0", optional = true }
 
 [dev-dependencies]
 alloy-rpc-types-eth = "0.12.5"
@@ -57,7 +60,11 @@ reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth.git", rev = "v1.3.
 ctor = "0.4.1"
 
 [features]
-integration = []
+integration = [
+    "dep:lazy_static",
+    "dep:time",
+    "dep:alloy-eips"
+]
 
 [[bin]]
 name = "rollup-boost"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,108 @@
+use clap::{Parser, Subcommand};
+use tracing::Level;
+
+use crate::{
+    client::rpc::{BuilderArgs, L2ClientArgs},
+    server::ExecutionMode,
+};
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about)]
+pub struct Args {
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+
+    #[clap(flatten)]
+    pub builder: BuilderArgs,
+
+    #[clap(flatten)]
+    pub l2_client: L2ClientArgs,
+
+    /// Disable using the proposer to sync the builder node
+    #[arg(long, env, default_value = "false")]
+    pub no_boost_sync: bool,
+
+    /// Host to run the server on
+    #[arg(long, env, default_value = "0.0.0.0")]
+    pub rpc_host: String,
+
+    /// Port to run the server on
+    #[arg(long, env, default_value = "8081")]
+    pub rpc_port: u16,
+
+    // Enable tracing
+    #[arg(long, env, default_value = "false")]
+    pub tracing: bool,
+
+    // Enable Prometheus metrics
+    #[arg(long, env, default_value = "false")]
+    pub metrics: bool,
+
+    /// Host to run the metrics server on
+    #[arg(long, env, default_value = "0.0.0.0")]
+    pub metrics_host: String,
+
+    /// Port to run the metrics server on
+    #[arg(long, env, default_value = "9090")]
+    pub metrics_port: u16,
+
+    /// OTLP endpoint
+    #[arg(long, env, default_value = "http://localhost:4317")]
+    pub otlp_endpoint: String,
+
+    /// Log level
+    #[arg(long, env, default_value = "info")]
+    pub log_level: Level,
+
+    /// Log format
+    #[arg(long, env, default_value = "text")]
+    pub log_format: LogFormat,
+
+    /// Host to run the debug server on
+    #[arg(long, env, default_value = "127.0.0.1")]
+    pub debug_host: String,
+
+    /// Debug server port
+    #[arg(long, env, default_value = "5555")]
+    pub debug_server_port: u16,
+
+    /// Execution mode to start rollup boost with
+    #[arg(long, env, default_value = "enabled")]
+    pub execution_mode: ExecutionMode,
+}
+
+#[derive(Clone, Debug)]
+pub enum LogFormat {
+    Json,
+    Text,
+}
+
+impl std::str::FromStr for LogFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "json" => Ok(LogFormat::Json),
+            "text" => Ok(LogFormat::Text),
+            _ => Err("Invalid log format".into()),
+        }
+    }
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Debug commands
+    Debug {
+        #[command(subcommand)]
+        command: DebugCommands,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum DebugCommands {
+    /// Set the execution mode
+    SetExecutionMode { execution_mode: ExecutionMode },
+
+    /// Get the execution mode
+    ExecutionMode {},
+}

--- a/src/client/http.rs
+++ b/src/client/http.rs
@@ -16,14 +16,14 @@ use tracing::{debug, error, instrument};
 use super::auth::{AuthClientLayer, AuthClientService};
 
 #[derive(Clone, Debug)]
-pub(crate) struct HttpClient {
+pub struct HttpClient {
     client: Decompression<AuthClientService<Client<HttpsConnector<HttpConnector>, HttpBody>>>,
     url: Uri,
     target: PayloadSource,
 }
 
 impl HttpClient {
-    pub(crate) fn new(url: Uri, secret: JwtSecret, target: PayloadSource) -> Self {
+    pub fn new(url: Uri, secret: JwtSecret, target: PayloadSource) -> Self {
         let connector = hyper_rustls::HttpsConnectorBuilder::new()
             .with_native_roots()
             .expect("no native root CA certificates found")

--- a/src/client/rpc.rs
+++ b/src/client/rpc.rs
@@ -23,7 +23,7 @@ const INTERNAL_ERROR: i32 = 13;
 pub(crate) type ClientResult<T> = Result<T, RpcClientError>;
 
 #[derive(Error, Debug)]
-pub(crate) enum RpcClientError {
+pub enum RpcClientError {
     #[error(transparent)]
     Jsonrpsee(#[from] jsonrpsee::core::client::Error),
     #[error("Invalid payload: {0}")]
@@ -89,7 +89,7 @@ impl From<RpcClientError> for ErrorObjectOwned {
 /// - **Engine API** calls are faciliated via the `auth_client` (requires JWT authentication).
 ///
 #[derive(Clone)]
-pub(crate) struct RpcClient {
+pub struct RpcClient {
     /// Handles requests to the authenticated Engine API (requires JWT authentication)
     auth_client: HttpClient<AuthClientService<HttpBackend>>,
     /// Uri of the RPC server for authenticated Engine API calls

--- a/src/health.rs
+++ b/src/health.rs
@@ -12,7 +12,7 @@ use tower::{Layer, Service, util::Either};
 
 /// A [`Layer`] that filters out /healthz requests and responds with a 200 OK.
 #[derive(Clone, Debug)]
-pub(crate) struct HealthLayer;
+pub struct HealthLayer;
 
 impl<S> Layer<S> for HealthLayer {
     type Service = HealthService<S>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,7 @@
-#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(
+    not(any(test, feature = "integration")),
+    warn(unused_crate_dependencies)
+)]
 
 use dotenv as _;
 use rustls as _;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,31 @@
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+use dotenv as _;
+use rustls as _;
+
+mod client;
+pub use client::{auth::*, http::*, rpc::*};
+
+mod cli;
+pub use cli::*;
+
+mod debug_api;
+pub use debug_api::*;
+
+mod health;
+pub use health::{HealthLayer, HealthService};
+
+#[cfg(all(feature = "integration", test))]
+mod integration;
+
+mod metrics;
+pub use metrics::*;
+
+mod proxy;
+pub use proxy::*;
+
+mod server;
+pub use server::*;
+
+mod tracing;
+pub use tracing::*;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -6,8 +6,6 @@ use metrics_util::layers::{PrefixLayer, Stack};
 use tokio::net::TcpListener;
 use tracing::{error, info};
 
-use crate::Args;
-
 use http::StatusCode;
 use hyper::service::service_fn;
 use hyper::{Request, Response, server::conn::http1};
@@ -15,7 +13,9 @@ use hyper_util::rt::TokioIo;
 use jsonrpsee::http_client::HttpBody;
 use metrics_exporter_prometheus::PrometheusHandle;
 
-pub(crate) fn init_metrics(args: &Args) -> Result<()> {
+use crate::cli::Args;
+
+pub fn init_metrics(args: &Args) -> Result<()> {
     if args.metrics {
         let recorder = PrometheusBuilder::new().build_recorder();
         let handle = recorder.handle();

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,5 +1,5 @@
-use crate::HealthLayer;
 use crate::client::http::HttpClient;
+use crate::health::HealthLayer;
 use crate::health::HealthService;
 use crate::server::PayloadSource;
 use alloy_rpc_types_engine::JwtSecret;

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -56,13 +56,13 @@ impl<S> Layer<S> for ProxyLayer {
     fn layer(&self, inner: S) -> Self::Service {
         let l2_client = HttpClient::new(
             self.l2_auth_rpc.clone(),
-            self.l2_auth_secret.clone(),
+            self.l2_auth_secret,
             PayloadSource::L2,
         );
 
         let builder_client = HttpClient::new(
             self.builder_auth_rpc.clone(),
-            self.builder_auth_secret.clone(),
+            self.builder_auth_secret,
             PayloadSource::Builder,
         );
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -274,7 +274,7 @@ impl EngineApiServer for RollupBoostServer {
             let builder_client = self.builder_client.clone();
             tokio::spawn(async move {
                 let _ = builder_client
-                    .fork_choice_updated_v3(fork_choice_state.clone(), payload_attributes.clone())
+                    .fork_choice_updated_v3(fork_choice_state, payload_attributes.clone())
                     .await;
             });
         } else {

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -51,13 +51,10 @@ impl SpanProcessor for MetricsSpanProcessor {
                     attr.value.as_str().to_string(),
                 )
             })
-            .chain(
-                [
-                    ("span_kind".to_string(), format!("{:?}", span.span_kind)),
-                    ("status".to_string(), status.into()),
-                ]
-                .into_iter(),
-            )
+            .chain([
+                ("span_kind".to_string(), format!("{:?}", span.span_kind)),
+                ("status".to_string(), status.into()),
+            ])
             .collect::<Vec<_>>();
 
         histogram!(format!("{}_duration", span.name), &labels).record(duration);

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -11,7 +11,7 @@ use tracing_subscriber::Layer;
 use tracing_subscriber::filter::Targets;
 use tracing_subscriber::layer::SubscriberExt;
 
-use crate::{Args, LogFormat};
+use crate::cli::{Args, LogFormat};
 
 /// Span attribute keys that should be recorded as metric labels.
 ///
@@ -72,7 +72,7 @@ impl SpanProcessor for MetricsSpanProcessor {
     }
 }
 
-pub(crate) fn init_tracing(args: &Args) -> eyre::Result<()> {
+pub fn init_tracing(args: &Args) -> eyre::Result<()> {
     // Be cautious with snake_case and kebab-case here
     let filter_name = "rollup_boost".to_string();
 


### PR DESCRIPTION
Refactors rollup-boost into a lib/bin such that it can be used as a dependency of other crates.

This PR also reduces the binary size by making dependencies behind feature flags optional, and removing all unused dependencies.