### PR TITLE
metrics updates

### DIFF
--- a/src/client/rpc.rs
+++ b/src/client/rpc.rs
@@ -12,7 +12,6 @@ use http::Uri;
 use jsonrpsee::http_client::transport::HttpBackend;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use jsonrpsee::types::ErrorObjectOwned;
-use metrics::counter;
 use op_alloy_rpc_types_engine::{
     OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4, OpExecutionPayloadV4,
     OpPayloadAttributes,
@@ -25,6 +24,9 @@ use thiserror::Error;
 use tracing::{error, info, instrument};
 
 const INTERNAL_ERROR: i32 = 13;
+const INVALID_PAYLOAD: i32 = 1337;
+const IO_ERROR: i32 = 1338;
+const JWT_ERROR: i32 = 1339;
 
 pub(crate) type ClientResult<T> = Result<T, RpcClientError>;
 
@@ -44,7 +46,8 @@ trait Code: Sized {
     fn code(&self) -> i32;
 
     fn set_code(self) -> Self {
-        tracing::Span::current().record("code", self.code());
+        let code_value: i64 = self.code().into();
+        tracing::Span::current().record("code", code_value.to_string());
         self
     }
 }
@@ -62,9 +65,10 @@ impl<T, E: Code> Code for Result<T, E> {
 impl Code for RpcClientError {
     fn code(&self) -> i32 {
         match self {
+            RpcClientError::InvalidPayload(_) => INVALID_PAYLOAD,
+            RpcClientError::Io(_) => IO_ERROR,
+            RpcClientError::Jwt(_) => JWT_ERROR,
             RpcClientError::Jsonrpsee(e) => e.code(),
-            // Status code 13 == internal error
-            _ => INTERNAL_ERROR,
         }
     }
 }
@@ -154,7 +158,7 @@ impl RpcClient {
         }
 
         if res.is_invalid() {
-            counter!("rpc_invalid_payload", "method" => "fork_choice_updated_v3", "payload_source" => self.payload_source.to_string()).increment(1);
+            error!("Invalid payload ({}): {:?}", self.payload_source, res);
             return Err(RpcClientError::InvalidPayload(
                 res.payload_status.status.to_string(),
             ))
@@ -172,6 +176,7 @@ impl RpcClient {
             target = self.payload_source.to_string(),
             url = %self.auth_rpc,
             %payload_id,
+            code,
         )
     )]
     pub async fn get_payload_v3(
@@ -215,7 +220,7 @@ impl RpcClient {
             .set_code()?;
 
         if res.is_invalid() {
-            counter!("rpc_invalid_payload", "method" => "new_payload_v3", "payload_source" => self.payload_source.to_string()).increment(1);
+            error!("Invalid payload ({}): {:?}", self.payload_source, res);
             return Err(RpcClientError::InvalidPayload(res.status.to_string()).set_code());
         }
 
@@ -230,6 +235,7 @@ impl RpcClient {
             target = self.payload_source.to_string(),
             url = %self.auth_rpc,
             %payload_id,
+            code,
         )
     )]
     pub async fn get_payload_v4(
@@ -294,7 +300,7 @@ impl RpcClient {
             .set_code()?;
 
         if res.is_invalid() {
-            counter!("rpc_invalid_payload", "method" => "new_payload_v4", "payload_source" => self.payload_source.to_string()).increment(1);
+            error!("Invalid payload ({}): {:?}", self.payload_source, res);
             return Err(RpcClientError::InvalidPayload(res.status.to_string()).set_code());
         }
 

--- a/src/client/rpc.rs
+++ b/src/client/rpc.rs
@@ -12,6 +12,7 @@ use http::Uri;
 use jsonrpsee::http_client::transport::HttpBackend;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use jsonrpsee::types::ErrorObjectOwned;
+use metrics::counter;
 use op_alloy_rpc_types_engine::{
     OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4, OpExecutionPayloadV4,
     OpPayloadAttributes,
@@ -153,6 +154,7 @@ impl RpcClient {
         }
 
         if res.is_invalid() {
+            counter!(format!("rpc_fork_choice_updated_v3_invalid_payload_{}", self.payload_source)).increment(1);
             return Err(RpcClientError::InvalidPayload(
                 res.payload_status.status.to_string(),
             ))
@@ -213,6 +215,7 @@ impl RpcClient {
             .set_code()?;
 
         if res.is_invalid() {
+            counter!(format!("rpc_new_payload_v3_invalid_payload_{}", self.payload_source)).increment(1);
             return Err(RpcClientError::InvalidPayload(res.status.to_string()).set_code());
         }
 
@@ -291,6 +294,7 @@ impl RpcClient {
             .set_code()?;
 
         if res.is_invalid() {
+            counter!(format!("rpc_new_payload_v4_invalid_payload_{}", self.payload_source)).increment(1);
             return Err(RpcClientError::InvalidPayload(res.status.to_string()).set_code());
         }
 
@@ -377,7 +381,7 @@ mod tests {
     use super::*;
 
     const AUTH_PORT: u32 = 8550;
-    const AUTH_ADDR: &str = "0.0.0.0";
+    const AUTH_ADDR: &str = "127.0.0.1";
     const SECRET: &str = "f79ae8046bc11c9927afe911db7143c51a806c4a537cc08e0d37140b0192f430";
 
     #[test]

--- a/src/client/rpc.rs
+++ b/src/client/rpc.rs
@@ -154,7 +154,7 @@ impl RpcClient {
         }
 
         if res.is_invalid() {
-            counter!(format!("rpc_fork_choice_updated_v3_invalid_payload_{}", self.payload_source)).increment(1);
+            counter!("rpc_invalid_payload", "method" => "fork_choice_updated_v3", "payload_source" => self.payload_source.to_string()).increment(1);
             return Err(RpcClientError::InvalidPayload(
                 res.payload_status.status.to_string(),
             ))
@@ -215,7 +215,7 @@ impl RpcClient {
             .set_code()?;
 
         if res.is_invalid() {
-            counter!(format!("rpc_new_payload_v3_invalid_payload_{}", self.payload_source)).increment(1);
+            counter!("rpc_invalid_payload", "method" => "new_payload_v3", "payload_source" => self.payload_source.to_string()).increment(1);
             return Err(RpcClientError::InvalidPayload(res.status.to_string()).set_code());
         }
 
@@ -294,7 +294,7 @@ impl RpcClient {
             .set_code()?;
 
         if res.is_invalid() {
-            counter!(format!("rpc_new_payload_v4_invalid_payload_{}", self.payload_source)).increment(1);
+            counter!("rpc_invalid_payload", "method" => "new_payload_v4", "payload_source" => self.payload_source.to_string()).increment(1);
             return Err(RpcClientError::InvalidPayload(res.status.to_string()).set_code());
         }
 

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -206,7 +206,7 @@ mod tests {
                 // None,
             ));
 
-            let temp_listener = TcpListener::bind("0.0.0.0:0").await?;
+            let temp_listener = TcpListener::bind("127.0.0.1:0").await?;
             let server_addr = temp_listener.local_addr()?;
             drop(temp_listener);
 
@@ -247,7 +247,7 @@ mod tests {
 
     impl MockHttpServer {
         async fn serve() -> eyre::Result<Self> {
-            let listener = TcpListener::bind("0.0.0.0:0").await?;
+            let listener = TcpListener::bind("127.0.0.1:0").await?;
             let addr = listener.local_addr()?;
             let requests = Arc::new(Mutex::new(vec![]));
 

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -1,5 +1,5 @@
 use eyre::Context as _;
-use metrics::histogram;
+use metrics::{counter, histogram};
 use opentelemetry::trace::{Status, TracerProvider as _};
 use opentelemetry::{KeyValue, global};
 use opentelemetry_otlp::WithExportConfig;
@@ -18,7 +18,7 @@ use crate::cli::{Args, LogFormat};
 /// Use caution when adding new attributes here and keep
 /// label cardinality in mind. Not all span attributes make
 /// appropriate labels.
-pub const SPAN_ATTRIBUTE_LABELS: [&str; 3] = ["code", "has_attributes", "payload_source"];
+pub const SPAN_ATTRIBUTE_LABELS: [&str; 5] = ["code", "has_attributes", "payload_source", "gas_delta", "tx_count_delta"];
 
 /// Custom span processor that records span durations as histograms
 #[derive(Debug)]
@@ -56,6 +56,29 @@ impl SpanProcessor for MetricsSpanProcessor {
                 ("status".to_string(), status.into()),
             ])
             .collect::<Vec<_>>();
+        
+        let payload_source = span.attributes.iter()
+            .find(|attr| attr.key.as_str() == "payload_source")
+            .map(|attr| attr.value.as_str().to_string())
+            .unwrap_or("unknown".to_string());
+
+        counter!("block_building_payload_returned", "payload_source" => payload_source.clone()).increment(1);
+
+        let gas_delta = span.attributes.iter()
+            .find(|attr| attr.key.as_str() == "gas_delta")
+            .map(|attr| attr.value.as_str().to_string());
+
+        if let Some(gas_delta) = gas_delta {
+            counter!("block_building_gas_delta").increment(gas_delta.parse::<u64>().unwrap_or_default());
+        }
+        
+        let tx_count_delta = span.attributes.iter()
+            .find(|attr| attr.key.as_str() == "tx_count_delta")
+            .map(|attr| attr.value.as_str().to_string());
+
+        if let Some(tx_count_delta) = tx_count_delta {
+            counter!("block_building_tx_count_delta").increment(tx_count_delta.parse::<u64>().unwrap_or_default());
+        }
 
         histogram!(format!("{}_duration", span.name), &labels).record(duration);
     }

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -57,17 +57,9 @@ impl SpanProcessor for MetricsSpanProcessor {
             ])
             .collect::<Vec<_>>();
 
-        let code = span
-            .attributes
-            .iter()
-            .find(|attr| attr.key.as_str() == "code")
-            .and_then(|attr| attr.value.as_str().parse::<i32>().ok())
-            .unwrap_or(0);
-
-        if code != 0 {
-            counter!("error", &labels).increment(1);
-        }
-
+        // 0 = no difference in gas build via builder vs l2
+        // > 0 = gas used by builder block is greater than l2 block
+        // < 0 = gas used by l2 block is greater than builder block
         let gas_delta = span
             .attributes
             .iter()
@@ -79,6 +71,9 @@ impl SpanProcessor for MetricsSpanProcessor {
                 .record(gas_delta.parse::<u64>().unwrap_or_default() as f64);
         }
 
+        // 0 = no difference in tx count build via builder vs l2
+        // > 0 = num txs in builder block is greater than l2 block
+        // < 0 = num txs in l2 block is greater than builder block
         let tx_count_delta = span
             .attributes
             .iter()


### PR DESCRIPTION
Adds a few metrics, also updates loopback IP in necessary places.

```
# TYPE rollup_boost_error counter
rollup_boost_error{code="-38001",span_kind="Client",status="error"} 1

# TYPE rollup_boost_block_building_gas_delta summary
rollup_boost_block_building_gas_delta{payload_source="builder",span_kind="Server",status="unset",quantile="0"} 0
...
rollup_boost_block_building_tx_count_delta_count{payload_source="builder",span_kind="Server",status="unset"} 1
```