### PR TITLE
chore: simplify `ProxyService::call()` logic

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -7,7 +7,7 @@ use jsonrpsee::http_client::{HttpBody, HttpRequest, HttpResponse};
 use std::task::{Context, Poll};
 use std::{future::Future, pin::Pin};
 use tower::{Layer, Service};
-use tracing::debug;
+use tracing::info;
 
 const ENGINE_METHOD: &str = "engine_";
 


### PR DESCRIPTION
Refactors `ProxyService::call` to simplify the request handling logic. Behavior is unchanged.

The updated flow is as follows:
- If it's an engine API method, send to the inner Rollup Boost server
- If it's a forwardable method, send to both the builder and the default execution client
- Otherwise,  send to the default execution client