### PR TITLE
Slow rollout feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3618,6 +3618,7 @@ dependencies = [
  "parking_lot",
  "paste",
  "predicates",
+ "rand 0.8.5",
  "reth-rpc-layer",
  "rustls",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ url = "2.5"
 metrics-util = "0.19.0"
 eyre = "0.6.12"
 paste = "1.0.15"
+rand = "0.8.5"
 
 # dev dependencies for integration tests
 parking_lot = "0.12.3"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -105,6 +105,7 @@ async fn main() -> eyre::Result<()> {
         boost_sync_enabled,
         args.execution_mode,
         flashblocks_client,
+        args.rollout_pct,
     );
 
     // Spawn the debug server

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,6 +73,10 @@ pub struct Args {
     /// Enable Flashblocks client
     #[clap(flatten)]
     pub flashblocks: FlashblocksArgs,
+
+    /// Percentage of blocks built by the builder
+    #[arg(long, env, default_value = "100")]
+    pub rollout_pct: u16,
 }
 
 #[derive(Parser, Debug)]


### PR DESCRIPTION
Adding a slow rollout feature where it'd only try to fetch the builder block x% of the time, this allows the rollout to happen in an incremental basis rather than all or nothing.