### PR TITLE
chore: simplify debug api

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -98,15 +98,15 @@ impl Args {
                 Commands::Debug { command } => match command {
                     DebugCommands::SetExecutionMode { execution_mode } => {
                         let client = DebugClient::new(debug_addr.as_str())?;
-                        let result = client.set_execution_mode(execution_mode).await.unwrap();
-                        println!("Response: {:?}", result.execution_mode);
+                        client.set_execution_mode(execution_mode).await?;
+                        println!("Successfully set execution mode to: {:?}", execution_mode);
 
                         Ok(())
                     }
                     DebugCommands::ExecutionMode {} => {
                         let client = DebugClient::new(debug_addr.as_str())?;
-                        let result = client.get_execution_mode().await?;
-                        println!("Execution mode: {:?}", result.execution_mode);
+                        let execution_mode = client.get_execution_mode().await?;
+                        println!("Execution mode: {:?}", execution_mode);
 
                         Ok(())
                     }

--- a/tests/execution_mode.rs
+++ b/tests/execution_mode.rs
@@ -53,24 +53,16 @@ async fn execution_mode() -> eyre::Result<()> {
 
     // enable dry run mode
     {
-        let response = client
-            .set_execution_mode(ExecutionMode::DryRun)
-            .await
-            .unwrap();
-        assert_eq!(response.execution_mode, ExecutionMode::DryRun);
+        client.set_execution_mode(ExecutionMode::DryRun).await?;
 
         // the new valid block should be created the the l2 builder
         let (_block, block_creator) = block_generator.generate_block(false).await?;
         assert!(block_creator.is_l2(), "Block creator should be l2");
     }
 
-    // toggle again dry run mode
+    // Enable execution mode again
     {
-        let response = client
-            .set_execution_mode(ExecutionMode::Enabled)
-            .await
-            .unwrap();
-        assert_eq!(response.execution_mode, ExecutionMode::Enabled);
+        client.set_execution_mode(ExecutionMode::Enabled).await?;
 
         // the new valid block should be created the the builder
         let (_block, block_creator) = block_generator.generate_block(false).await?;
@@ -90,11 +82,7 @@ async fn execution_mode() -> eyre::Result<()> {
     // to track the number of calls to the builder during the disabled mode which
     // should be 0
     {
-        let response = client
-            .set_execution_mode(ExecutionMode::Disabled)
-            .await
-            .unwrap();
-        assert_eq!(response.execution_mode, ExecutionMode::Disabled);
+        client.set_execution_mode(ExecutionMode::Disabled).await?;
 
         // reset the counter in the proxy
         *counter.lock().unwrap() = 0;


### PR DESCRIPTION
This PR simplifies the Debug API by removing boilerplate request/response structs and updates to use the `ExecutionMode` type directly instead. Tests have been update to reflect the API changes. Below is a quick look at the changes:

### Previous: 
```rust
// --snip--
#[derive(Serialize, Deserialize, Debug)]
pub struct SetExecutionModeRequest {
    pub execution_mode: ExecutionMode,
}

#[derive(Serialize, Deserialize, Clone, Debug)]
pub struct SetExecutionModeResponse {
    pub execution_mode: ExecutionMode,
}

#[derive(Serialize, Deserialize, Clone, Debug)]
pub struct GetExecutionModeResponse {
    pub execution_mode: ExecutionMode,
}

#[rpc(server, client, namespace = "debug")]
trait DebugApi {
    #[method(name = "setExecutionMode")]
    async fn set_execution_mode(
        &self,
        request: SetExecutionModeRequest,
    ) -> RpcResult<SetExecutionModeResponse>;

    #[method(name = "getExecutionMode")]
    async fn get_execution_mode(&self) -> RpcResult<GetExecutionModeResponse>;
}

```

### Updated
```rust
// --snip--
#[rpc(server, client, namespace = "debug")]
trait DebugApi {
    #[method(name = "setExecutionMode")]
    async fn set_execution_mode(&self, request: ExecutionMode) -> RpcResult<()>;

    #[method(name = "getExecutionMode")]
    async fn get_execution_mode(&self) -> RpcResult<ExecutionMode>;
}
```