### PR TITLE
Process engine requests sequentially

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -142,7 +142,7 @@ pub enum EngineMessage {
     },
     ForkchoiceUpdated {
         fork_choice_state: ForkchoiceState,
-        payload_attributes: Option<OpPayloadAttributes>,
+        payload_attributes: Box<Option<OpPayloadAttributes>>,
         tx: oneshot::Sender<RpcResult<ForkchoiceUpdated>>,
     },
     GetPayload {
@@ -313,7 +313,7 @@ impl EngineHandler {
         let (tx, rx) = oneshot::channel();
         let _ = self.to_engine.send(EngineMessage::ForkchoiceUpdated {
             fork_choice_state,
-            payload_attributes,
+            payload_attributes: Box::new(payload_attributes),
             tx,
         });
 
@@ -558,7 +558,7 @@ impl RollupBoostServer {
                     tx,
                 } => {
                     let result = self
-                        .fork_choice_updated_v3(fork_choice_state, payload_attributes)
+                        .fork_choice_updated_v3(fork_choice_state, *payload_attributes)
                         .await;
                     let _ = tx.send(result);
                 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -310,6 +310,7 @@ pub struct SimpleBlockGenerator {
     latest_hash: B256,
     timestamp: u64,
     version: Version,
+    block_time_sec: u64,
 }
 
 impl SimpleBlockGenerator {
@@ -320,7 +321,12 @@ impl SimpleBlockGenerator {
             latest_hash: B256::ZERO, // temporary value
             timestamp: 0,            // temporary value
             version: Version::V3,
+            block_time_sec: 1,
         }
+    }
+
+    pub fn set_block_time(&mut self, block_time_sec: u64) {
+        self.block_time_sec = block_time_sec;
     }
 
     /// Initialize the block generator by fetching the latest block
@@ -368,8 +374,8 @@ impl SimpleBlockGenerator {
 
         let payload_id = result.payload_id.expect("missing payload id");
 
-        if !empty_blocks {
-            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+        if !empty_blocks && self.block_time_sec > 0 {
+            tokio::time::sleep(tokio::time::Duration::from_secs(self.block_time_sec)).await;
         }
 
         let payload = self

--- a/tests/common/proxy.rs
+++ b/tests/common/proxy.rs
@@ -86,6 +86,8 @@ async fn proxy(
 
     let json_rpc_response = serde_json::from_slice::<JsonRpcResponse>(&bytes).unwrap();
     let bytes = if let Some(result) = json_rpc_response.clone().result {
+        println!("Received response: {:?}", json_rpc_response.id);
+
         let value = config
             .handler
             .handle(json_rpc_request.method, json_rpc_request.params, result)

--- a/tests/common/proxy.rs
+++ b/tests/common/proxy.rs
@@ -86,8 +86,6 @@ async fn proxy(
 
     let json_rpc_response = serde_json::from_slice::<JsonRpcResponse>(&bytes).unwrap();
     let bytes = if let Some(result) = json_rpc_response.clone().result {
-        println!("Received response: {:?}", json_rpc_response.id);
-
         let value = config
             .handler
             .handle(json_rpc_request.method, json_rpc_request.params, result)

--- a/tests/engine_calls_in_order.rs
+++ b/tests/engine_calls_in_order.rs
@@ -15,5 +15,7 @@ async fn engine_calls_in_order() -> eyre::Result<()> {
         let (_block, _block_creator) = block_generator.generate_block(false).await?;
     }
 
+    // TODO: check condition
+
     Ok(())
 }

--- a/tests/engine_calls_in_order.rs
+++ b/tests/engine_calls_in_order.rs
@@ -1,0 +1,37 @@
+mod common;
+
+use common::{RollupBoostTestHarnessBuilder, proxy::ProxyHandler};
+use futures::FutureExt as _;
+use serde_json::Value;
+use std::pin::Pin;
+use std::sync::Arc;
+
+struct Handler;
+
+impl ProxyHandler for Handler {
+    fn handle(
+        &self,
+        _method: String,
+        _params: Value,
+        _result: Value,
+    ) -> Pin<Box<dyn Future<Output = Option<Value>> + Send>> {
+        async move { None }.boxed()
+    }
+}
+
+#[tokio::test]
+async fn engine_calls_in_order() -> eyre::Result<()> {
+    let harness = RollupBoostTestHarnessBuilder::new("engine_calls_in_order")
+        .proxy_handler(Arc::new(Handler))
+        .build()
+        .await?;
+
+    let mut block_generator = harness.block_generator().await?;
+    block_generator.set_block_time(0);
+
+    for _ in 0..100 {
+        let (_block, _block_creator) = block_generator.generate_block(false).await?;
+    }
+
+    Ok(())
+}

--- a/tests/engine_calls_in_order.rs
+++ b/tests/engine_calls_in_order.rs
@@ -1,28 +1,10 @@
 mod common;
 
-use common::{RollupBoostTestHarnessBuilder, proxy::ProxyHandler};
-use futures::FutureExt as _;
-use serde_json::Value;
-use std::pin::Pin;
-use std::sync::Arc;
-
-struct Handler;
-
-impl ProxyHandler for Handler {
-    fn handle(
-        &self,
-        _method: String,
-        _params: Value,
-        _result: Value,
-    ) -> Pin<Box<dyn Future<Output = Option<Value>> + Send>> {
-        async move { None }.boxed()
-    }
-}
+use common::RollupBoostTestHarnessBuilder;
 
 #[tokio::test]
 async fn engine_calls_in_order() -> eyre::Result<()> {
     let harness = RollupBoostTestHarnessBuilder::new("engine_calls_in_order")
-        .proxy_handler(Arc::new(Handler))
         .build()
         .await?;
 


### PR DESCRIPTION
This PR changes how we handle engine API requests by processing them sequentially rather than concurrently. The changes implement a message-passing architecture with an EngineHandler that forwards requests to the main RollupBoostServer through a channel.

Motivation:

- Alignment with EL expectations: Execution Layer expects to receive and process messages in sequence, not in parallel
- Concurrency control: Prevents race conditions when the Consensus Layer sends many requests in a short timeframe

TODO: Write the success condition in the e2e test.