### PR TITLE
feat: simplify ExecutionMode

### DIFF
--- a/src/debug_api.rs
+++ b/src/debug_api.rs
@@ -152,17 +152,5 @@ mod tests {
         // Verify again with get_execution_mode
         let status = client.get_execution_mode().await.unwrap();
         assert_eq!(status.execution_mode, ExecutionMode::Enabled);
-
-        // Test setting fallback execution mode
-        let result = client
-            .set_execution_mode(ExecutionMode::Fallback)
-            .await
-            .unwrap();
-
-        assert_eq!(result.execution_mode, ExecutionMode::Fallback);
-
-        // Verify again with get_execution_mode
-        let status = client.get_execution_mode().await.unwrap();
-        assert_eq!(status.execution_mode, ExecutionMode::Fallback);
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -628,7 +628,10 @@ impl RollupBoostServer {
                     Ok(payload)
                 }
 
-                Err(e) => Err(e.into()),
+                Err(e) => {
+                    self.probes.set_health(Health::ServiceUnavailable);
+                    Err(e.into())
+                }
             };
         }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -611,17 +611,16 @@ impl RollupBoostServer {
             return match l2_fut.await {
                 Ok(payload) => {
                     self.probes.set_health(Health::Healthy);
-                    tracing::Span::current()
-                        .record("payload_source", PayloadSource::L2.to_string());
-                    counter!("rpc.blocks_created", "source" => PayloadSource::L2.to_string())
-                        .increment(1);
+                    let context = PayloadSource::L2;
+                    tracing::Span::current().record("payload_source", context.to_string());
+                    counter!("rpc.blocks_created", "source" => context.to_string()).increment(1);
 
                     let execution_payload = ExecutionPayload::from(payload.clone());
                     info!(
                         message = "returning block",
                         "hash" = %execution_payload.block_hash(),
                         "number" = %execution_payload.block_number(),
-                        context = PayloadSource::L2.to_string(),
+                        %context,
                         %payload_id,
                     );
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -611,15 +611,17 @@ impl RollupBoostServer {
             return match l2_fut.await {
                 Ok(payload) => {
                     self.probes.set_health(Health::Healthy);
-                    tracing::Span::current().record("payload_source", "L2");
-                    counter!("rpc.blocks_created", "source" => "L2").increment(1);
+                    tracing::Span::current()
+                        .record("payload_source", PayloadSource::L2.to_string());
+                    counter!("rpc.blocks_created", "source" => PayloadSource::L2.to_string())
+                        .increment(1);
 
                     let execution_payload = ExecutionPayload::from(payload.clone());
                     info!(
                         message = "returning block",
                         "hash" = %execution_payload.block_hash(),
                         "number" = %execution_payload.block_number(),
-                        context = "L2",
+                        context = PayloadSource::L2.to_string(),
                         %payload_id,
                     );
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -629,29 +629,67 @@ impl RollupBoostServer {
             Ok(Some(payload))
         });
 
-        let (l2_payload, builder_payload) = tokio::join!(l2_client_future, builder_client_future);
-        let (payload, context) = match (builder_payload, l2_payload) {
-            (Ok(Some(builder)), Ok(l2_payload)) => {
-                // builder successfully returned a payload
-                self.probes.set_health(Health::Healthy);
-                if self.execution_mode().is_dry_run() {
-                    // Default to op-geth's payload
-                    Ok((l2_payload, PayloadSource::L2))
-                } else {
+        let execution_mode = self.execution_mode();
+
+        // if mode is `dry_run` dont want to wait for the builder payload
+        let (payload, context) = if execution_mode.is_dry_run() {
+            let result = match l2_client_future.await {
+                Ok(payload) => {
+                    self.probes.set_health(Health::Healthy);
+                    Ok((payload, PayloadSource::L2))
+                }
+                Err(e) => {
+                    self.probes.set_health(Health::ServiceUnavailable);
+                    Err(e)
+                }
+            };
+            result
+        } else {
+            let (l2_payload, builder_payload) =
+                tokio::join!(l2_client_future, builder_client_future);
+            let result = match (builder_payload, l2_payload) {
+                (Ok(Some(builder)), Ok(_)) => {
+                    // builder successfully returned a payload
+                    self.probes.set_health(Health::Healthy);
                     Ok((builder, PayloadSource::Builder))
                 }
-            }
-            (_, Ok(l2)) => {
-                // builder failed to return a payload
-                self.probes.set_health(Health::PartialContent);
-                Ok((l2, PayloadSource::L2))
-            }
-            (_, Err(e)) => {
-                // builder and l2 failed to return a payload
-                self.probes.set_health(Health::ServiceUnavailable);
-                Err(e)
-            }
+                (_, Ok(l2)) => {
+                    // builder failed to return a payload
+                    self.probes.set_health(Health::PartialContent);
+                    Ok((l2, PayloadSource::L2))
+                }
+                (_, Err(e)) => {
+                    // builder and l2 failed to return a payload
+                    self.probes.set_health(Health::ServiceUnavailable);
+                    Err(e)
+                }
+            };
+            result
         }?;
+
+        // let (l2_payload, builder_payload) = tokio::join!(l2_client_future, builder_client_future);
+        // let (payload, context) = match (builder_payload, l2_payload) {
+        //     (Ok(Some(builder)), Ok(l2_payload)) => {
+        //         // builder successfully returned a payload
+        //         self.probes.set_health(Health::Healthy);
+        //         if self.execution_mode().is_dry_run() {
+        //             // Default to op-geth's payload
+        //             Ok((l2_payload, PayloadSource::L2))
+        //         } else {
+        //             Ok((builder, PayloadSource::Builder))
+        //         }
+        //     }
+        //     (_, Ok(l2)) => {
+        //         // builder failed to return a payload
+        //         self.probes.set_health(Health::PartialContent);
+        //         Ok((l2, PayloadSource::L2))
+        //     }
+        //     (_, Err(e)) => {
+        //         // builder and l2 failed to return a payload
+        //         self.probes.set_health(Health::ServiceUnavailable);
+        //         Err(e)
+        //     }
+        // }?;
 
         tracing::Span::current().record("payload_source", context.to_string());
         // To maintain backwards compatibility with old metrics, we need to record blocks built


### PR DESCRIPTION
Fixes #196 

Changes made:
- Removed `Fallback` mode from `ExecutionMode`
- `DryRun` mode will get both `l2_payload` and `builder_payload`, but will always send the `l2_payload`. This was different previously where in DryRun, the call to `builder_payload` would return an error. 