### PR TITLE
Add log for fcu

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -314,7 +314,15 @@ impl EngineApiServer for RollupBoostServer {
         fork_choice_state: ForkchoiceState,
         payload_attributes: Option<OpPayloadAttributes>,
     ) -> RpcResult<ForkchoiceUpdated> {
-        info!("received fork_choice_updated_v3");
+        if let Some(attr) = payload_attributes.as_ref() {
+            info!(
+                message = "received fork_choice_updated_v3 with payload attributes",
+                "use_tx_pool" = !attr.no_tx_pool.unwrap_or_default()
+            );
+        } else {
+            info!("received fork_choice_updated_v3");
+        }
+
         // First get the local payload ID from L2 client
         let l2_response = self
             .l2_client


### PR DESCRIPTION
This PR adds a log to print the specific type of FCU call and whether the txpool is enabled for the one that triggers block building.

To give some extra context, during the block building lifecycle there are two FCU calls, one for block building and one after the block has been included on chain. This logs helps to differentiate both cases.
