### PR TITLE
feat: process Engine API requests sequentially

### DIFF
--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -76,8 +76,8 @@ where
             builder_client,
             engine_tx: tx,
         };
-        service.process_engine_queue(rx);
 
+        service.process_engine_queue(rx);
         service
     }
 }
@@ -108,7 +108,6 @@ where
         )>,
     ) {
         let mut service = self.clone();
-
         tokio::spawn(async move {
             while let Some((req, resp_tx)) = rx.recv().await {
                 let resp = service.inner.call(req).await.map_err(|e| e.into());
@@ -164,7 +163,6 @@ where
 
                 let (tx, rx) = oneshot::channel();
                 engine_tx.send((req, tx)).unwrap();
-
                 rx.await.expect("TODO: handle error")
             } else if FORWARD_REQUESTS.contains(&method.as_str()) {
                 // If the request should be forwarded, send to both the

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -112,8 +112,8 @@ where
         tokio::spawn(async move {
             while let Some((req, resp_tx)) = rx.recv().await {
                 let resp = service.inner.call(req).await.map_err(|e| e.into());
-                // Note that we can unwrap here since the rx will only be dropped if the rollup
-                // boostserver has been shut down
+                // Note that we can unwrap here since the rx will only be dropped
+                // if the rollup boost server has been shut down
                 resp_tx.send(resp).unwrap();
             }
         });

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -6,7 +6,7 @@ use jsonrpsee::core::{BoxError, http_helpers};
 use jsonrpsee::http_client::{HttpBody, HttpRequest, HttpResponse};
 use std::task::{Context, Poll};
 use std::{future::Future, pin::Pin};
-use tokio::sync::mpsc::{Sender, UnboundedReceiver, UnboundedSender};
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot;
 use tower::{Layer, Service};
 use tracing::info;


### PR DESCRIPTION
Addresses #188, simplifies #192

This PR updates the ProxyService to process all Engine API requests sequentially.  Instead of forwarding Engine requests directly to the inner service, they’re now enqueued along with a response channel, and a separate task processes the queue. This guarantees that Engine API calls are processed sequentially while still allowing all other RPC calls to be processed concurrently. 