### PR TITLE
Add a test to ensure a FCU call without block delay can be built by the builder

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -28,7 +28,7 @@ use std::net::TcpListener;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::{Arc, LazyLock};
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 use std::{fs::File, io::BufReader, time::UNIX_EPOCH};
 use testcontainers::core::ContainerPort;
 use testcontainers::core::client::docker_client_instance;
@@ -385,6 +385,7 @@ pub struct SimpleBlockGenerator {
     timestamp: u64,
     genesis: Genesis,
     current_block_number: u64,
+    block_time: Duration,
 }
 
 impl SimpleBlockGenerator {
@@ -400,7 +401,12 @@ impl SimpleBlockGenerator {
             timestamp: genesis.timestamp,
             genesis,
             current_block_number: 0,
+            block_time: Duration::from_secs(1),
         }
+    }
+
+    pub fn set_block_time(&mut self, block_time: Duration) {
+        self.block_time = block_time;
     }
 
     /// Initialize the block generator by fetching the latest block

--- a/tests/fcu_avalanche_with_delay.rs
+++ b/tests/fcu_avalanche_with_delay.rs
@@ -1,0 +1,60 @@
+mod common;
+
+use common::RollupBoostTestHarnessBuilder;
+use common::proxy::ProxyHandler;
+use futures::FutureExt;
+use serde_json::Value;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+// Create a dynamic handler that delays all the calls by 2 seconds
+struct DelayHandler {
+    delay: Duration,
+}
+
+impl DelayHandler {
+    pub fn new(delay: Duration) -> Self {
+        Self { delay }
+    }
+}
+
+impl ProxyHandler for DelayHandler {
+    fn handle(
+        &self,
+        _method: String,
+        _params: Value,
+        _result: Value,
+    ) -> Pin<Box<dyn Future<Output = Option<Value>> + Send>> {
+        let delay = self.delay;
+        async move {
+            tokio::time::sleep(delay).await;
+            None
+        }
+        .boxed()
+    }
+}
+
+#[tokio::test]
+async fn fcu_avalanche_with_delay() -> eyre::Result<()> {
+    // This test ensures that even with delay in between RB and the external builder (50ms) the
+    // builder can still build the block
+    let delay = DelayHandler::new(Duration::from_millis(50));
+
+    let harness = RollupBoostTestHarnessBuilder::new("fcu_avalanche_with_delay")
+        .proxy_handler(Arc::new(delay))
+        .build()
+        .await?;
+    let mut block_generator = harness.block_generator().await?;
+    block_generator.set_block_time(Duration::from_millis(0));
+
+    for _ in 0..30 {
+        let (_block, block_creator) = block_generator.generate_block(false).await?;
+        assert!(
+            block_creator.is_builder(),
+            "Block creator should be the builder"
+        );
+    }
+
+    Ok(())
+}

--- a/tests/fcu_no_block_time_delay.rs
+++ b/tests/fcu_no_block_time_delay.rs
@@ -36,12 +36,12 @@ impl ProxyHandler for DelayHandler {
 }
 
 #[tokio::test]
-async fn fcu_avalanche_with_delay() -> eyre::Result<()> {
+async fn fcu_no_block_time_delay() -> eyre::Result<()> {
     // This test ensures that even with delay in between RB and the external builder (50ms) the
-    // builder can still build the block
+    // builder can still build the block if there is an avalanche of FCUs without block time delay
     let delay = DelayHandler::new(Duration::from_millis(50));
 
-    let harness = RollupBoostTestHarnessBuilder::new("fcu_avalanche_with_delay")
+    let harness = RollupBoostTestHarnessBuilder::new("fcu_no_block_time_delay")
         .proxy_handler(Arc::new(delay))
         .build()
         .await?;

--- a/tests/fcu_no_block_time_delay.rs
+++ b/tests/fcu_no_block_time_delay.rs
@@ -8,7 +8,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
-// Create a dynamic handler that delays all the calls by 2 seconds
+// TODO: Use the same implementation as in builder_full_delay.rs
 struct DelayHandler {
     delay: Duration,
 }


### PR DESCRIPTION
Closes #227 