### PR TITLE
[Draft] Add Engine API abstraction

### DIFF
--- a/src/client/rpc.rs
+++ b/src/client/rpc.rs
@@ -11,6 +11,7 @@ use alloy_rpc_types_engine::{
 use alloy_rpc_types_eth::{Block, BlockNumberOrTag};
 use clap::{Parser, arg};
 use http::Uri;
+use jsonrpsee::core::async_trait;
 use jsonrpsee::http_client::transport::HttpBackend;
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use jsonrpsee::types::ErrorObjectOwned;
@@ -334,6 +335,17 @@ impl RpcClient {
             .get_block_by_number(number, full)
             .await
             .set_code()?)
+    }
+}
+
+#[async_trait]
+impl EngineApiClient for RpcClient {
+    async fn get_block_by_number(
+        &self,
+        number: BlockNumberOrTag,
+        full: bool,
+    ) -> ClientResult<Block> {
+        self.get_block_by_number(number, full).await
     }
 }
 

--- a/src/engine_api.rs
+++ b/src/engine_api.rs
@@ -1,0 +1,233 @@
+use alloy_primitives::{B256, Bytes};
+use alloy_rpc_types_engine::{
+    ExecutionPayload, ExecutionPayloadV3, ForkchoiceState, ForkchoiceUpdated, PayloadId,
+    PayloadStatus,
+};
+use alloy_rpc_types_eth::{Block, BlockNumberOrTag};
+use jsonrpsee::{
+    core::{RpcResult, async_trait},
+    proc_macros::rpc,
+};
+use op_alloy_rpc_types_engine::{
+    OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4, OpExecutionPayloadV4,
+    OpPayloadAttributes,
+};
+
+use crate::ClientResult;
+
+#[rpc(server, client)]
+pub trait EngineApi {
+    #[method(name = "engine_forkchoiceUpdatedV3")]
+    async fn fork_choice_updated_v3(
+        &self,
+        fork_choice_state: ForkchoiceState,
+        payload_attributes: Option<OpPayloadAttributes>,
+    ) -> RpcResult<ForkchoiceUpdated>;
+
+    #[method(name = "engine_getPayloadV3")]
+    async fn get_payload_v3(
+        &self,
+        payload_id: PayloadId,
+    ) -> RpcResult<OpExecutionPayloadEnvelopeV3>;
+
+    #[method(name = "engine_newPayloadV3")]
+    async fn new_payload_v3(
+        &self,
+        payload: ExecutionPayloadV3,
+        versioned_hashes: Vec<B256>,
+        parent_beacon_block_root: B256,
+    ) -> RpcResult<PayloadStatus>;
+
+    #[method(name = "engine_getPayloadV4")]
+    async fn get_payload_v4(
+        &self,
+        payload_id: PayloadId,
+    ) -> RpcResult<OpExecutionPayloadEnvelopeV4>;
+
+    #[method(name = "engine_newPayloadV4")]
+    async fn new_payload_v4(
+        &self,
+        payload: OpExecutionPayloadV4,
+        versioned_hashes: Vec<B256>,
+        parent_beacon_block_root: B256,
+        execution_requests: Vec<Bytes>,
+    ) -> RpcResult<PayloadStatus>;
+
+    #[method(name = "eth_getBlockByNumber")]
+    async fn get_block_by_number(&self, number: BlockNumberOrTag, full: bool) -> RpcResult<Block>;
+}
+
+#[derive(Debug, Clone)]
+pub struct NewPayloadV3 {
+    pub payload: ExecutionPayloadV3,
+    pub versioned_hashes: Vec<B256>,
+    pub parent_beacon_block_root: B256,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewPayloadV4 {
+    pub payload: OpExecutionPayloadV4,
+    pub versioned_hashes: Vec<B256>,
+    pub parent_beacon_block_root: B256,
+    pub execution_requests: Vec<Bytes>,
+}
+
+#[derive(Debug, Clone)]
+pub enum NewPayload {
+    V3(NewPayloadV3),
+    V4(NewPayloadV4),
+}
+
+impl NewPayload {
+    pub fn version(&self) -> Version {
+        match self {
+            NewPayload::V3(_) => Version::V3,
+            NewPayload::V4(_) => Version::V4,
+        }
+    }
+}
+
+impl From<OpExecutionPayloadEnvelope> for NewPayload {
+    fn from(envelope: OpExecutionPayloadEnvelope) -> Self {
+        match envelope {
+            OpExecutionPayloadEnvelope::V3(v3) => NewPayload::V3(NewPayloadV3 {
+                payload: v3.execution_payload,
+                versioned_hashes: vec![],
+                parent_beacon_block_root: v3.parent_beacon_block_root,
+            }),
+            OpExecutionPayloadEnvelope::V4(v4) => NewPayload::V4(NewPayloadV4 {
+                payload: v4.execution_payload,
+                versioned_hashes: vec![],
+                parent_beacon_block_root: v4.parent_beacon_block_root,
+                execution_requests: v4.execution_requests,
+            }),
+        }
+    }
+}
+
+impl From<NewPayload> for ExecutionPayload {
+    fn from(new_payload: NewPayload) -> Self {
+        match new_payload {
+            NewPayload::V3(v3) => ExecutionPayload::from(v3.payload),
+            NewPayload::V4(v4) => ExecutionPayload::from(v4.payload.payload_inner),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum OpExecutionPayloadEnvelope {
+    V3(OpExecutionPayloadEnvelopeV3),
+    V4(OpExecutionPayloadEnvelopeV4),
+}
+
+impl OpExecutionPayloadEnvelope {
+    pub fn version(&self) -> Version {
+        match self {
+            OpExecutionPayloadEnvelope::V3(_) => Version::V3,
+            OpExecutionPayloadEnvelope::V4(_) => Version::V4,
+        }
+    }
+}
+
+impl From<OpExecutionPayloadEnvelope> for ExecutionPayload {
+    fn from(envelope: OpExecutionPayloadEnvelope) -> Self {
+        match envelope {
+            OpExecutionPayloadEnvelope::V3(v3) => ExecutionPayload::from(v3.execution_payload),
+            OpExecutionPayloadEnvelope::V4(v4) => {
+                ExecutionPayload::from(v4.execution_payload.payload_inner)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum Version {
+    V3,
+    V4,
+}
+
+impl Version {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Version::V3 => "v3",
+            Version::V4 => "v4",
+        }
+    }
+}
+
+#[async_trait]
+pub trait EngineApiExt {
+    async fn fork_choice_updated_v3(
+        &self,
+        fork_choice_state: ForkchoiceState,
+        payload_attributes: Option<OpPayloadAttributes>,
+    ) -> ClientResult<ForkchoiceUpdated>;
+
+    async fn new_payload_v3(
+        &self,
+        payload: ExecutionPayloadV3,
+        versioned_hashes: Vec<B256>,
+        parent_beacon_block_root: B256,
+    ) -> ClientResult<PayloadStatus>;
+
+    async fn new_payload_v4(
+        &self,
+        payload: OpExecutionPayloadV4,
+        versioned_hashes: Vec<B256>,
+        parent_beacon_block_root: B256,
+        execution_requests: Vec<Bytes>,
+    ) -> ClientResult<PayloadStatus>;
+
+    async fn new_payload(&self, new_payload: NewPayload) -> ClientResult<PayloadStatus> {
+        match new_payload {
+            NewPayload::V3(new_payload) => {
+                self.new_payload_v3(
+                    new_payload.payload,
+                    new_payload.versioned_hashes,
+                    new_payload.parent_beacon_block_root,
+                )
+                .await
+            }
+            NewPayload::V4(new_payload) => {
+                self.new_payload_v4(
+                    new_payload.payload,
+                    new_payload.versioned_hashes,
+                    new_payload.parent_beacon_block_root,
+                    new_payload.execution_requests,
+                )
+                .await
+            }
+        }
+    }
+
+    async fn get_payload_v3(
+        &self,
+        payload_id: PayloadId,
+    ) -> ClientResult<OpExecutionPayloadEnvelopeV3>;
+
+    async fn get_payload_v4(
+        &self,
+        payload_id: PayloadId,
+    ) -> ClientResult<OpExecutionPayloadEnvelopeV4>;
+
+    async fn get_payload(
+        &self,
+        payload_id: PayloadId,
+        version: Version,
+    ) -> ClientResult<OpExecutionPayloadEnvelope> {
+        match version {
+            Version::V3 => Ok(OpExecutionPayloadEnvelope::V3(
+                self.get_payload_v3(payload_id).await?,
+            )),
+            Version::V4 => Ok(OpExecutionPayloadEnvelope::V4(
+                self.get_payload_v4(payload_id).await?,
+            )),
+        }
+    }
+
+    async fn get_block_by_number(
+        &self,
+        number: BlockNumberOrTag,
+        full: bool,
+    ) -> ClientResult<Block>;
+}

--- a/src/health.rs
+++ b/src/health.rs
@@ -10,16 +10,19 @@ use tokio::{
 };
 use tracing::warn;
 
-use crate::{Health, Probes, RpcClient};
+use crate::{EngineApiExt, Health, Probes};
 
-pub struct HealthHandle {
+pub struct HealthHandle<BuilderClient> {
     pub probes: Arc<Probes>,
-    pub builder_client: Arc<RpcClient>,
+    pub builder_client: Arc<BuilderClient>,
     pub health_check_interval: u64,
     pub max_unsafe_interval: u64,
 }
 
-impl HealthHandle {
+impl<BuilderClient> HealthHandle<BuilderClient>
+where
+    BuilderClient: Clone + Sync + Send + EngineApiExt + 'static,
+{
     /// Periodically checks that the latest unsafe block timestamp is not older than the
     /// the current time minus the max_unsafe_interval.
     pub fn spawn(self) -> JoinHandle<()> {

--- a/src/health.rs
+++ b/src/health.rs
@@ -79,7 +79,7 @@ mod tests {
     use tokio::net::TcpListener;
 
     use super::*;
-    use crate::{PayloadSource, Probes};
+    use crate::{PayloadSource, Probes, RpcClient};
 
     pub struct MockHttpServer {
         addr: SocketAddr,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,3 +27,6 @@ pub use probe::*;
 
 mod health;
 pub use health::*;
+
+mod engine_api;
+pub use engine_api::*;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,6 @@
 use crate::{
-    ClientResult, HealthHandle, RpcClientError,
+    EngineApiExt, EngineApiServer, HealthHandle, NewPayload, NewPayloadV3, NewPayloadV4,
+    OpExecutionPayloadEnvelope, Version,
     client::rpc::RpcClient,
     debug_api::DebugServer,
     probe::{Health, Probes},
@@ -20,7 +21,6 @@ use alloy_rpc_types_engine::{
 };
 use jsonrpsee::RpcModule;
 use jsonrpsee::core::{RegisterMethodError, RpcResult, async_trait};
-use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::types::ErrorObject;
 use jsonrpsee::types::error::INVALID_REQUEST_CODE;
 use op_alloy_rpc_types_engine::{
@@ -121,7 +121,10 @@ impl PayloadTraceContext {
     }
 }
 
-pub struct RollupBoostServer<BuilderClient> {
+pub struct RollupBoostServer<BuilderClient>
+where
+    BuilderClient: Clone + Sync + Send + EngineApiExt,
+{
     pub l2_client: Arc<RpcClient>,
     pub builder_client: Arc<BuilderClient>,
     pub payload_trace_context: Arc<PayloadTraceContext>,
@@ -132,7 +135,7 @@ pub struct RollupBoostServer<BuilderClient> {
 
 impl<BuilderClient> RollupBoostServer<BuilderClient>
 where
-    BuilderClient: Clone,
+    BuilderClient: Sync + Send + Clone + EngineApiExt + 'static,
 {
     pub fn new(
         l2_client: RpcClient,
@@ -218,91 +221,6 @@ impl PayloadSource {
         matches!(self, PayloadSource::L2)
     }
 }
-
-#[rpc(server, client)]
-pub trait EngineApi {
-    #[method(name = "engine_forkchoiceUpdatedV3")]
-    async fn fork_choice_updated_v3(
-        &self,
-        fork_choice_state: ForkchoiceState,
-        payload_attributes: Option<OpPayloadAttributes>,
-    ) -> RpcResult<ForkchoiceUpdated>;
-
-    #[method(name = "engine_getPayloadV3")]
-    async fn get_payload_v3(
-        &self,
-        payload_id: PayloadId,
-    ) -> RpcResult<OpExecutionPayloadEnvelopeV3>;
-
-    #[method(name = "engine_newPayloadV3")]
-    async fn new_payload_v3(
-        &self,
-        payload: ExecutionPayloadV3,
-        versioned_hashes: Vec<B256>,
-        parent_beacon_block_root: B256,
-    ) -> RpcResult<PayloadStatus>;
-
-    #[method(name = "engine_getPayloadV4")]
-    async fn get_payload_v4(
-        &self,
-        payload_id: PayloadId,
-    ) -> RpcResult<OpExecutionPayloadEnvelopeV4>;
-
-    #[method(name = "engine_newPayloadV4")]
-    async fn new_payload_v4(
-        &self,
-        payload: OpExecutionPayloadV4,
-        versioned_hashes: Vec<B256>,
-        parent_beacon_block_root: B256,
-        execution_requests: Vec<Bytes>,
-    ) -> RpcResult<PayloadStatus>;
-
-    #[method(name = "eth_getBlockByNumber")]
-    async fn get_block_by_number(&self, number: BlockNumberOrTag, full: bool) -> RpcResult<Block>;
-}
-
-#[async_trait]
-pub trait EngineApiExt: EngineApiClient {
-    async fn new_payload(&self, new_payload: NewPayload) -> ClientResult<PayloadStatus> {
-        match new_payload {
-            NewPayload::V3(new_payload) => self
-                .new_payload_v3(
-                    new_payload.payload,
-                    new_payload.versioned_hashes,
-                    new_payload.parent_beacon_block_root,
-                )
-                .await
-                .map_err(|e| RpcClientError::from(e)),
-            NewPayload::V4(new_payload) => self
-                .new_payload_v4(
-                    new_payload.payload,
-                    new_payload.versioned_hashes,
-                    new_payload.parent_beacon_block_root,
-                    new_payload.execution_requests,
-                )
-                .await
-                .map_err(|e| RpcClientError::from(e)),
-        }
-    }
-
-    async fn get_payload(
-        &self,
-        payload_id: PayloadId,
-        version: Version,
-    ) -> ClientResult<OpExecutionPayloadEnvelope> {
-        match version {
-            Version::V3 => Ok(OpExecutionPayloadEnvelope::V3(
-                self.get_payload_v3(payload_id).await?,
-            )),
-            Version::V4 => Ok(OpExecutionPayloadEnvelope::V4(
-                self.get_payload_v4(payload_id).await?,
-            )),
-        }
-    }
-}
-
-// Automatically implement the extension trait for any type that implements EngineApi
-impl<T: EngineApiClient + ?Sized> EngineApiExt for T {}
 
 #[async_trait]
 impl<BuilderClient> EngineApiServer for RollupBoostServer<BuilderClient>
@@ -509,104 +427,6 @@ where
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum OpExecutionPayloadEnvelope {
-    V3(OpExecutionPayloadEnvelopeV3),
-    V4(OpExecutionPayloadEnvelopeV4),
-}
-
-impl OpExecutionPayloadEnvelope {
-    pub fn version(&self) -> Version {
-        match self {
-            OpExecutionPayloadEnvelope::V3(_) => Version::V3,
-            OpExecutionPayloadEnvelope::V4(_) => Version::V4,
-        }
-    }
-}
-
-impl From<OpExecutionPayloadEnvelope> for ExecutionPayload {
-    fn from(envelope: OpExecutionPayloadEnvelope) -> Self {
-        match envelope {
-            OpExecutionPayloadEnvelope::V3(v3) => ExecutionPayload::from(v3.execution_payload),
-            OpExecutionPayloadEnvelope::V4(v4) => {
-                ExecutionPayload::from(v4.execution_payload.payload_inner)
-            }
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct NewPayloadV3 {
-    pub payload: ExecutionPayloadV3,
-    pub versioned_hashes: Vec<B256>,
-    pub parent_beacon_block_root: B256,
-}
-
-#[derive(Debug, Clone)]
-pub struct NewPayloadV4 {
-    pub payload: OpExecutionPayloadV4,
-    pub versioned_hashes: Vec<B256>,
-    pub parent_beacon_block_root: B256,
-    pub execution_requests: Vec<Bytes>,
-}
-
-#[derive(Debug, Clone)]
-pub enum NewPayload {
-    V3(NewPayloadV3),
-    V4(NewPayloadV4),
-}
-
-impl NewPayload {
-    pub fn version(&self) -> Version {
-        match self {
-            NewPayload::V3(_) => Version::V3,
-            NewPayload::V4(_) => Version::V4,
-        }
-    }
-}
-
-impl From<OpExecutionPayloadEnvelope> for NewPayload {
-    fn from(envelope: OpExecutionPayloadEnvelope) -> Self {
-        match envelope {
-            OpExecutionPayloadEnvelope::V3(v3) => NewPayload::V3(NewPayloadV3 {
-                payload: v3.execution_payload,
-                versioned_hashes: vec![],
-                parent_beacon_block_root: v3.parent_beacon_block_root,
-            }),
-            OpExecutionPayloadEnvelope::V4(v4) => NewPayload::V4(NewPayloadV4 {
-                payload: v4.execution_payload,
-                versioned_hashes: vec![],
-                parent_beacon_block_root: v4.parent_beacon_block_root,
-                execution_requests: v4.execution_requests,
-            }),
-        }
-    }
-}
-
-impl From<NewPayload> for ExecutionPayload {
-    fn from(new_payload: NewPayload) -> Self {
-        match new_payload {
-            NewPayload::V3(v3) => ExecutionPayload::from(v3.payload),
-            NewPayload::V4(v4) => ExecutionPayload::from(v4.payload.payload_inner),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-pub enum Version {
-    V3,
-    V4,
-}
-
-impl Version {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Version::V3 => "v3",
-            Version::V4 => "v4",
-        }
-    }
-}
-
 impl<BuilderClient> RollupBoostServer<BuilderClient>
 where
     BuilderClient: Clone + Sync + Send + EngineApiExt + 'static,
@@ -750,6 +570,7 @@ mod tests {
     use crate::proxy::ProxyLayer;
 
     use super::*;
+    use crate::engine_api::EngineApiClient;
     use alloy_primitives::hex;
     use alloy_primitives::{FixedBytes, U256};
     use alloy_rpc_types_engine::JwtSecret;


### PR DESCRIPTION
This PR adds an engine API trait to the RollupBoostServer such that there can be several implementations for the backend RB logic. Some of the names are TBD.