### PR TITLE
refactor: error handling

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -101,7 +101,7 @@ impl Args {
                 Commands::Debug { command } => match command {
                     DebugCommands::SetExecutionMode { execution_mode } => {
                         let client = DebugClient::new(debug_addr.as_str())?;
-                        let result = client.set_execution_mode(execution_mode).await.unwrap();
+                        let result = client.set_execution_mode(execution_mode).await?;
                         println!("Response: {:?}", result.execution_mode);
 
                         Ok(())

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -90,9 +90,7 @@ pub struct Args {
 
 impl Args {
     pub async fn run(self) -> eyre::Result<()> {
-        rustls::crypto::ring::default_provider()
-            .install_default()
-            .expect("Failed to install TLS ring CryptoProvider");
+        let _ = rustls::crypto::ring::default_provider().install_default();
 
         let debug_addr = format!("{}:{}", self.debug_host, self.debug_server_port);
 

--- a/src/client/auth.rs
+++ b/src/client/auth.rs
@@ -77,12 +77,12 @@ pub fn secret_to_bearer_header(secret: &JwtSecret) -> HeaderValue {
             .encode(&Claims {
                 iat: SystemTime::now()
                     .duration_since(UNIX_EPOCH)
-                    .unwrap()
+                    .expect("Failed to get epoch time")
                     .as_secs(),
                 exp: None,
             })
-            .unwrap()
+            .expect("Failed to encode JWT claims")
     )
     .parse()
-    .unwrap()
+    .expect("Failed to parse JWT Header")
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -46,12 +46,13 @@ async fn init_metrics_server(addr: SocketAddr, handle: PrometheusHandle) -> eyre
                             "/metrics" => Response::builder()
                                 .header("content-type", "text/plain")
                                 .body(HttpBody::from(handle.render()))
-                                .unwrap(),
+                                .expect("Failed to create metrics response"),
                             _ => Response::builder()
                                 .status(StatusCode::NOT_FOUND)
                                 .body(HttpBody::empty())
-                                .unwrap(),
+                                .expect("Failed to create not found response"),
                         };
+
                         async { Ok::<_, hyper::Error>(response) }
                     });
 

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -127,19 +127,19 @@ fn ok() -> HttpResponse<HttpBody> {
     HttpResponse::builder()
         .status(200)
         .body(HttpBody::from("OK"))
-        .unwrap()
+        .expect("Failed to create OK reponse")
 }
 
 fn partial_content() -> HttpResponse<HttpBody> {
     HttpResponse::builder()
         .status(206)
         .body(HttpBody::from("Partial Content"))
-        .unwrap()
+        .expect("Failed to create partial content response")
 }
 
 fn service_unavailable() -> HttpResponse<HttpBody> {
     HttpResponse::builder()
         .status(503)
         .body(HttpBody::from("Service Unavailable"))
-        .unwrap()
+        .expect("Failed to create service unavailable response")
 }


### PR DESCRIPTION
Replaces some .unwrap/.expects with error propagation (with context).

Changed unwraps to expects in prod code