### PR TITLE
chore: update Rust Ci action

### DIFF
--- a/.github/workflows/kurtosis_integration.yml
+++ b/.github/workflows/kurtosis_integration.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           profile: minimal

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
           uses: actions/checkout@v2
   
         - name: Set up Rust
-          uses: actions-rs/toolchain@v1
+          uses: dtolnay/rust-toolchain@stable
           with:
             toolchain: stable
             override: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
       - name: Install cargo-nextest

--- a/.github/workflows/websocket-proxy-ci.yaml
+++ b/.github/workflows/websocket-proxy-ci.yaml
@@ -25,7 +25,7 @@ jobs:
           sudo apt-get install -y redis
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           override: true


### PR DESCRIPTION
The `actions-rs/toolchain` Github action has been archived. Update to a maintained one.