### PR TITLE
fix: skip health status update during `ExecutionMode::DryRun`

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -179,14 +179,19 @@ impl RollupBoostServer {
             self.probes.set_health(Health::Healthy);
 
             if let Ok(Some(payload)) = builder_payload {
+                // If execution mode is set to DryRun, fallback to the l2_payload,
+                // otherwise prefer the builder payload
                 if self.execution_mode().is_dry_run() {
                     (l2_payload, PayloadSource::L2)
                 } else {
-                    // NOTE: block selection policy
                     (payload, PayloadSource::Builder)
                 }
             } else {
-                self.probes.set_health(Health::PartialContent);
+                // Only update the health status if the builder payload fails
+                // and execution mode is not set to DryRun
+                if !self.execution_mode().is_dry_run() {
+                    self.probes.set_health(Health::PartialContent);
+                }
                 (l2_payload, PayloadSource::L2)
             }
         };


### PR DESCRIPTION
This PR updates the builder health check logic to avoid degrading health status during `ExecutionMode::DryRun`. Currently, a builder failure during `DryRun causes the health to be reported as `Partial` triggering sequencer failover. With this change, dry run failures are ignored for health reporting purposes.