### PR TITLE
Osiris/monotonic timestamps

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,7 +97,7 @@ impl Args {
 
         // Handle commands if present
         if let Some(cmd) = self.command {
-            let debug_addr = format!("http://{}", debug_addr);
+            let debug_addr = format!("http://{debug_addr}");
             return match cmd {
                 Commands::Debug { command } => match command {
                     DebugCommands::SetExecutionMode { execution_mode } => {

--- a/src/health.rs
+++ b/src/health.rs
@@ -324,4 +324,24 @@ mod tests {
 
         assert!(t2 >= t1 + 1,);
     }
+
+    #[tokio::test]
+    async fn tick_matches_system_clock() {
+        let mut ts = MonotonicTimestamp::new();
+        let unix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs();
+
+        assert_eq!(ts.last_unix, unix);
+
+        std::thread::sleep(Duration::from_secs(5));
+
+        let t1 = ts.tick();
+        let unix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs();
+        assert_eq!(t1, unix);
+    }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -28,6 +28,7 @@ use op_alloy_rpc_types_engine::{
 use opentelemetry::trace::SpanKind;
 use parking_lot::Mutex;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::task::JoinHandle;
 use tracing::{info, instrument};
 
@@ -52,7 +53,7 @@ impl RollupBoostServer {
         let health_handle = HealthHandle {
             probes: probes.clone(),
             builder_client: Arc::new(builder_client.clone()),
-            health_check_interval,
+            health_check_interval: Duration::from_secs(health_check_interval),
             max_unsafe_interval,
         }
         .spawn();


### PR DESCRIPTION
Improves accuracy, and robustness of unix time calculation in the health handle by removing repeated reliance on the system clock which is not guaranteed to be monotonic (e.g., via NTP, manual clock changes, or suspend/resume, etc.).

This can cause false `PartialHealth` status codes to be incorrectly set in rollup-boost, and trigger unnecessary failovers.