### PR TITLE
websocket proxy: disconnect downstream client if lagging

### DIFF
--- a/crates/websocket-proxy/src/metrics.rs
+++ b/crates/websocket-proxy/src/metrics.rs
@@ -21,9 +21,6 @@ pub struct Metrics {
     #[metric(describe = "Count of rate limited request")]
     pub rate_limited_requests: Counter,
 
-    #[metric(describe = "Count of times that a client lagged")]
-    pub lag_events: Counter,
-
     #[metric(describe = "Count of times upstream receiver was closed/errored")]
     pub upstream_errors: Counter,
 

--- a/crates/websocket-proxy/src/metrics.rs
+++ b/crates/websocket-proxy/src/metrics.rs
@@ -15,6 +15,9 @@ pub struct Metrics {
     #[metric(describe = "Count of number of connections closed")]
     pub closed_connections: Counter,
 
+    #[metric(describe = "Count the number of connections which lagged and then disconnected")]
+    pub lagged_connections: Counter,
+
     #[metric(describe = "Number of client connections currently open")]
     pub active_connections: Gauge,
 

--- a/crates/websocket-proxy/src/registry.rs
+++ b/crates/websocket-proxy/src/registry.rs
@@ -47,6 +47,7 @@ impl Registry {
                     }
                     Err(RecvError::Lagged(_)) => {
                         info!(message = "client is lagging", client = client.id());
+                        metrics.lagged_connections.increment(1);
                         break;
                     }
                 }

--- a/crates/websocket-proxy/src/registry.rs
+++ b/crates/websocket-proxy/src/registry.rs
@@ -47,8 +47,7 @@ impl Registry {
                     }
                     Err(RecvError::Lagged(_)) => {
                         info!(message = "client is lagging", client = client.id());
-                        metrics.lag_events.increment(1);
-                        receiver = receiver.resubscribe();
+                        break;
                     }
                 }
             }


### PR DESCRIPTION


we want to disconnect clients who are receiving packets but not active - could be due to device going to sleep, browser tab going to sleep, slow code in message processing on client side, etc. 

previously attempted to solve via adding ping/pong between ws proxy and downstream clients. but we realized that just changing the behaviour of what happens when clients start lagging has the same effect, and more responsive. 

we've noticed on base sepolia that lagging clients typically do not benefit from a resubscription and continue to remain lagging, indicative of an issue on their end. looking at lag metrics right now, a single client on average causes the lag event to trigger 40-50 times, i.e. ~8-10seconds. the worst offenders go for 30+ seconds. 

we'd rather disconnect them when they start lagging (i.e. fall 4 seconds behind based on default config values of our broadcast buffer size). if clients wish, they can reconnect themselves.