### PR TITLE
Add builder has payload attribute to metrics

### DIFF
--- a/crates/rollup-boost/src/tests/common/services/rollup_boost.rs
+++ b/crates/rollup-boost/src/tests/common/services/rollup_boost.rs
@@ -31,6 +31,12 @@ impl RollupBoost {
     pub fn debug_endpoint(&self) -> String {
         format!("http://localhost:{}", self.args.debug_server_port)
     }
+
+    pub async fn get_metrics(&self) -> eyre::Result<String> {
+        let response = reqwest::get(self.metrics_endpoint() + "/metrics").await?;
+        let body = response.text().await?;
+        Ok(body)
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/crates/rollup-boost/src/tracing.rs
+++ b/crates/rollup-boost/src/tracing.rs
@@ -19,7 +19,8 @@ use crate::cli::{Args, LogFormat};
 /// Use caution when adding new attributes here and keep
 /// label cardinality in mind. Not all span attributes make
 /// appropriate labels.
-pub const SPAN_ATTRIBUTE_LABELS: [&str; 4] = ["code", "payload_source", "method", "builder_has_payload"];
+pub const SPAN_ATTRIBUTE_LABELS: [&str; 4] =
+    ["code", "payload_source", "method", "builder_has_payload"];
 
 /// Custom span processor that records span durations as histograms
 #[derive(Debug)]
@@ -40,7 +41,7 @@ impl SpanProcessor for MetricsSpanProcessor {
             Status::Error { .. } => "error",
             Status::Unset => "unset",
         };
-        
+
         // Add custom labels
         let labels = span
             .attributes

--- a/crates/rollup-boost/src/tracing.rs
+++ b/crates/rollup-boost/src/tracing.rs
@@ -19,7 +19,7 @@ use crate::cli::{Args, LogFormat};
 /// Use caution when adding new attributes here and keep
 /// label cardinality in mind. Not all span attributes make
 /// appropriate labels.
-pub const SPAN_ATTRIBUTE_LABELS: [&str; 4] = ["code", "has_attributes", "payload_source", "method"];
+pub const SPAN_ATTRIBUTE_LABELS: [&str; 4] = ["code", "payload_source", "method", "builder_has_payload"];
 
 /// Custom span processor that records span durations as histograms
 #[derive(Debug)]
@@ -40,7 +40,7 @@ impl SpanProcessor for MetricsSpanProcessor {
             Status::Error { .. } => "error",
             Status::Unset => "unset",
         };
-
+        
         // Add custom labels
         let labels = span
             .attributes


### PR DESCRIPTION
Resolves https://github.com/flashbots/rollup-boost/issues/253. Removed the `has_attributes` since it was not being included in the span attributes and unused