### PR TITLE
Do not update health status when execution mode = Disabled

### DIFF
--- a/crates/rollup-boost/src/debug_api.rs
+++ b/crates/rollup-boost/src/debug_api.rs
@@ -25,6 +25,10 @@ impl ExecutionMode {
     pub fn is_disabled(&self) -> bool {
         matches!(self, ExecutionMode::Disabled)
     }
+
+    pub fn is_enabled(&self) -> bool {
+        matches!(self, ExecutionMode::Enabled)
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -35,7 +35,7 @@ use opentelemetry::trace::SpanKind;
 use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{info, instrument};
+use tracing::{info, instrument, warn};
 
 pub type Request = HttpRequest;
 pub type Response = HttpResponse;
@@ -215,8 +215,8 @@ impl RollupBoostServer {
                     self.probes.set_health(Health::PartialContent);
                 }
                 else {
-                    warn!(target: "rollup_boost::server", 
-                    message: "Builder payload failed. However, health status is not updated to PartialContent because of the current execution mode");
+                    warn!(target = "rollup_boost::server", 
+                    message = "Builder payload failed. However, health status is not updated to PartialContent because of the current execution mode");
                 }
                 (l2_payload, PayloadSource::L2)
             }

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -210,9 +210,13 @@ impl RollupBoostServer {
                 }
             } else {
                 // Only update the health status if the builder payload fails
-                // and execution mode is not set to DryRun
-                if !self.execution_mode().is_dry_run() {
+                // and execution mode is set to Enabled
+                if self.execution_mode().is_enabled() {
                     self.probes.set_health(Health::PartialContent);
+                }
+                else {
+                    warn!(target: "rollup_boost::server", 
+                    message: "Builder payload failed. However, health status is not updated to PartialContent because of the current execution mode");
                 }
                 (l2_payload, PayloadSource::L2)
             }


### PR DESCRIPTION
On builder payload failures, we should only update the health status if the execution mode is Enabled

Instead, I added a WARN log

Testing still in progress...