### PR TITLE
Add cli command to configure builder websocket reconnection time

### DIFF
--- a/crates/rollup-boost/src/cli.rs
+++ b/crates/rollup-boost/src/cli.rs
@@ -178,6 +178,7 @@ impl Args {
                 builder_client.clone(),
                 inbound_url,
                 outbound_addr,
+                self.flashblocks.flashblock_builder_ws_reconnect_ms,
             )?)
         } else {
             Arc::new(builder_client)

--- a/crates/rollup-boost/src/flashblocks/args.rs
+++ b/crates/rollup-boost/src/flashblocks/args.rs
@@ -18,4 +18,8 @@ pub struct FlashblocksArgs {
     /// Flashblocks WebSocket port for outbound connections
     #[arg(long, env, default_value = "1112")]
     pub flashblocks_port: u16,
+
+    /// Time used for timeout if builder disconnected
+    #[arg(long, env, default_value = "5000")]
+    pub flashblock_builder_ws_reconnect_ms: u64,
 }

--- a/crates/rollup-boost/src/flashblocks/launcher.rs
+++ b/crates/rollup-boost/src/flashblocks/launcher.rs
@@ -11,10 +11,11 @@ impl Flashblocks {
         builder_url: RpcClient,
         flashblocks_url: Url,
         outbound_addr: SocketAddr,
+        reconnect_ms: u64,
     ) -> eyre::Result<FlashblocksService> {
         let (tx, rx) = mpsc::channel(100);
 
-        let receiver = FlashblocksReceiverService::new(flashblocks_url, tx);
+        let receiver = FlashblocksReceiverService::new(flashblocks_url, tx, reconnect_ms);
         tokio::spawn(async move {
             let _ = receiver.run().await;
         });


### PR DESCRIPTION
It would be convenient to have this configuration to test different approaches on staging and to set it up depending on block time 