### PR TITLE
Return sha over prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,6 +1071,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.26",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,6 +1468,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1999,6 +2062,19 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "git2"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
+dependencies = [
+ "bitflags 2.9.1",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
 
 [[package]]
 name = "glob"
@@ -2820,6 +2896,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.1+1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1dcb20f84ffcdd825c7a311ae347cce604a6f084a767dec4a4929829645290e"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2844,6 +2932,18 @@ dependencies = [
  "bitflags 2.9.1",
  "libc",
  "redox_syscall 0.5.12",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3173,6 +3273,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
  "libc",
 ]
 
@@ -4096,6 +4205,8 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
+ "vergen",
+ "vergen-git2",
 ]
 
 [[package]]
@@ -4433,6 +4544,9 @@ name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "semver-parser"
@@ -4979,7 +5093,9 @@ checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -5474,6 +5590,47 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "9.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b2bf58be11fc9414104c6d3a2e464163db5ef74b12296bda593cac37b6e4777"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+ "derive_builder",
+ "regex",
+ "rustversion",
+ "time",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-git2"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f6ee511ec45098eabade8a0750e76eec671e7fb2d9360c563911336bea9cac1"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "git2",
+ "rustversion",
+ "time",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+]
 
 [[package]]
 name = "version_check"

--- a/crates/rollup-boost/Cargo.toml
+++ b/crates/rollup-boost/Cargo.toml
@@ -26,7 +26,11 @@ tokio-tungstenite.workspace = true
 
 # TODO: update to latest release when it is published
 # jsonrpsee = { version = "0.25.1", features = ["server", "http-client", "macros"] }
-jsonrpsee = { git = "https://github.com/paritytech/jsonrpsee", rev = "f04afa740e55db60dce20d9839758792f035ffff", features = ["server", "http-client", "macros"]}
+jsonrpsee = { git = "https://github.com/paritytech/jsonrpsee", rev = "f04afa740e55db60dce20d9839758792f035ffff", features = [
+    "server",
+    "http-client",
+    "macros",
+] }
 moka = { version = "0.12.10", features = ["future"] }
 http = "1.1.0"
 dotenvy = "0.15.7"
@@ -71,6 +75,10 @@ bytes = "1.2"
 reth-rpc-layer = { git = "https://github.com/paradigmxyz/reth.git", tag = "v1.4.7" }
 ctor = "0.4.1"
 reqwest = "0.12.15"
+
+[build-dependencies]
+vergen = { version = "9.0.4", features = ["build", "cargo", "emit_and_set"] }
+vergen-git2 = "1.0.5"
 
 [[bin]]
 name = "rollup-boost"

--- a/crates/rollup-boost/build.rs
+++ b/crates/rollup-boost/build.rs
@@ -1,0 +1,27 @@
+use std::{env, error::Error};
+use vergen::{BuildBuilder, Emitter};
+use vergen_git2::Git2Builder;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut emitter = Emitter::default();
+
+    let build_builder = BuildBuilder::default().build_timestamp(true).build()?;
+    emitter.add_instructions(&build_builder)?;
+
+    let git_builder = Git2Builder::default()
+        .describe(false, true, None)
+        .dirty(true)
+        .sha(false)
+        .build()?;
+
+    emitter.add_instructions(&git_builder)?;
+
+    emitter.emit_and_set()?;
+    let sha = env::var("VERGEN_GIT_SHA")?;
+    let sha_short = &sha[0..7];
+
+    // Set short SHA
+    println!("cargo:rustc-env=VERGEN_GIT_SHA_SHORT={}", &sha_short);
+
+    Ok(())
+}

--- a/crates/rollup-boost/src/cli.rs
+++ b/crates/rollup-boost/src/cli.rs
@@ -17,13 +17,13 @@ use crate::{
     RollupBoostServer, RpcClient,
     client::rpc::{BuilderArgs, L2ClientArgs},
     debug_api::ExecutionMode,
-    init_metrics,
+    get_version, init_metrics,
     payload::PayloadSource,
     probe::ProbeLayer,
 };
 
 #[derive(Clone, Parser, Debug)]
-#[clap(author, version, about)]
+#[clap(author, version = get_version(), about)]
 pub struct Args {
     #[command(subcommand)]
     pub command: Option<Commands>,

--- a/crates/rollup-boost/src/lib.rs
+++ b/crates/rollup-boost/src/lib.rs
@@ -43,3 +43,6 @@ mod consistent_request;
 
 mod engine_api;
 pub use engine_api::*;
+
+mod version;
+pub use version::*;

--- a/crates/rollup-boost/src/version.rs
+++ b/crates/rollup-boost/src/version.rs
@@ -1,0 +1,45 @@
+use metrics::gauge;
+
+/// The latest version from Cargo.toml.
+pub const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// The 8 character short SHA of the latest commit.
+pub const VERGEN_GIT_SHA: &str = env!("VERGEN_GIT_SHA_SHORT");
+
+/// The build timestamp.
+pub const VERGEN_BUILD_TIMESTAMP: &str = env!("VERGEN_BUILD_TIMESTAMP");
+
+pub const VERSION: VersionInfo = VersionInfo {
+    version: CARGO_PKG_VERSION,
+    build_timestamp: VERGEN_BUILD_TIMESTAMP,
+    git_sha: VERGEN_GIT_SHA,
+};
+
+/// Contains version information for the application.
+#[derive(Debug, Clone)]
+pub struct VersionInfo {
+    /// The version of the application.
+    pub version: &'static str,
+    /// The build timestamp of the application.
+    pub build_timestamp: &'static str,
+    /// The Git SHA of the build.
+    pub git_sha: &'static str,
+}
+
+impl VersionInfo {
+    /// This exposes rollup-boost's version information over prometheus.
+    pub fn register_version_metrics(&self) {
+        let labels: [(&str, &str); 3] = [
+            ("version", self.version),
+            ("build_timestamp", self.build_timestamp),
+            ("git_sha", self.git_sha),
+        ];
+
+        let gauge = gauge!("builder_info", &labels);
+        gauge.set(1);
+    }
+}
+
+pub fn get_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}


### PR DESCRIPTION
This PR uses a build script and [vergen](https://github.com/rustyhorde/vergen) to make the git sha available during runtime. Necessary for #293 