### PR TITLE
Fix FB race

### DIFF
--- a/crates/rollup-boost/src/flashblocks/inbound.rs
+++ b/crates/rollup-boost/src/flashblocks/inbound.rs
@@ -141,7 +141,7 @@ mod tests {
         });
 
         // Send a message to the websocket server
-        let _ = send_msg
+        send_msg
             .send(FlashblocksPayloadV1::default())
             .await
             .expect("Failed to send message");
@@ -158,7 +158,7 @@ mod tests {
 
         // start a new server with the same address
         let (term, send_msg, _url) = start(addr).await?;
-        let _ = send_msg
+        send_msg
             .send(FlashblocksPayloadV1::default())
             .await
             .expect("Failed to send message");

--- a/crates/websocket-proxy/src/subscriber.rs
+++ b/crates/websocket-proxy/src/subscriber.rs
@@ -366,6 +366,6 @@ mod tests {
         assert!(messages.contains(&"Another message from server 1".to_string()));
         assert!(messages.contains(&"Another message from server 2".to_string()));
 
-        assert!(messages.len() > 0);
+        assert!(!messages.is_empty());
     }
 }


### PR DESCRIPTION
Run make fmt
Added check to ensure that we returning block constructed from flashblock
Removed double lock - this changed behavior a bit, but even if into_envelope fails we would have FlashblockBuilder::new() in best_payload