### PR TITLE
Use User-agent in RB header

### DIFF
--- a/crates/rollup-boost/src/client/rpc.rs
+++ b/crates/rollup-boost/src/client/rpc.rs
@@ -121,7 +121,7 @@ impl RpcClient {
     ) -> Result<Self, RpcClientError> {
         let version = format!("{}-{}", CARGO_PKG_VERSION, VERGEN_GIT_SHA);
         let mut headers = HeaderMap::new();
-        headers.insert("X-Rollup-Boost-Version", version.parse().unwrap());
+        headers.insert("User-Agent", version.parse().unwrap());
 
         let auth_layer = AuthLayer::new(auth_rpc_jwt_secret);
         let auth_client = HttpClientBuilder::new()


### PR DESCRIPTION
Uses `User-Agent` key in Rollup-boost Http call header that includes the version.