### PR TITLE
ws proxy: brotli compress each message from upstream before sending downstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1766,6 +1766,7 @@ version = "0.1.0"
 dependencies = [
  "axum 0.8.4",
  "backoff",
+ "brotli",
  "clap",
  "dotenvy",
  "futures",

--- a/crates/websocket-proxy/Cargo.toml
+++ b/crates/websocket-proxy/Cargo.toml
@@ -32,10 +32,11 @@ redis = "0.30.0"
 redis-test = { version = "0.10.0", optional = true }
 uuid = { version = "1.16.0", features = ["v4"] }
 tokio-util = "0.7.12"
-brotli = "8.0.1"
+brotli = { version = "8.0.1", optional = true }
 
 [dependencies.ring]
 version = "0.17.12"
 
 [features]
 integration = ["redis-test"]
+compression = ["brotli"]

--- a/crates/websocket-proxy/Cargo.toml
+++ b/crates/websocket-proxy/Cargo.toml
@@ -32,11 +32,10 @@ redis = "0.30.0"
 redis-test = { version = "0.10.0", optional = true }
 uuid = { version = "1.16.0", features = ["v4"] }
 tokio-util = "0.7.12"
-brotli = { version = "8.0.1", optional = true }
+brotli = "8.0.1"
 
 [dependencies.ring]
 version = "0.17.12"
 
 [features]
 integration = ["redis-test"]
-compression = ["brotli"]

--- a/crates/websocket-proxy/Cargo.toml
+++ b/crates/websocket-proxy/Cargo.toml
@@ -32,6 +32,7 @@ redis = "0.30.0"
 redis-test = { version = "0.10.0", optional = true }
 uuid = { version = "1.16.0", features = ["v4"] }
 tokio-util = "0.7.12"
+brotli = "8.0.1"
 
 [dependencies.ring]
 version = "0.17.12"

--- a/crates/websocket-proxy/README.md
+++ b/crates/websocket-proxy/README.md
@@ -62,3 +62,8 @@ When Redis is enabled, the following features are available:
 
 If the Redis connection fails, the proxy will automatically fall back to in-memory rate limiting.
 
+### Brotli Compression
+
+The proxy supports compressing messages to downstream clients using Brotli.
+
+To enable this, pass the parameter `--enable-compression`

--- a/crates/websocket-proxy/src/client.rs
+++ b/crates/websocket-proxy/src/client.rs
@@ -18,8 +18,8 @@ impl ClientConnection {
         }
     }
 
-    pub async fn send(&mut self, data: String) -> Result<(), Error> {
-        self.websocket.send(data.into_bytes().into()).await
+    pub async fn send(&mut self, data: Vec<u8>) -> Result<(), Error> {
+        self.websocket.send(data.into()).await
     }
 
     pub fn id(&self) -> String {

--- a/crates/websocket-proxy/src/integration.rs
+++ b/crates/websocket-proxy/src/integration.rs
@@ -27,7 +27,7 @@ mod test {
         server: Server,
         server_addr: SocketAddr,
         client_id_to_handle: HashMap<usize, JoinHandle<()>>,
-        sender: Sender<String>,
+        sender: Sender<Vec<u8>>,
     }
 
     impl TestHarness {
@@ -153,7 +153,10 @@ mod test {
         }
 
         fn send_messages(&mut self, messages: Vec<&str>) {
-            let messages: Vec<String> = messages.into_iter().map(String::from).collect();
+            let messages: Vec<Vec<u8>> = messages
+                .into_iter()
+                .map(|m| m.as_bytes().to_vec())
+                .collect();
 
             for message in messages.iter() {
                 match self.sender.send(message.clone()) {

--- a/crates/websocket-proxy/src/main.rs
+++ b/crates/websocket-proxy/src/main.rs
@@ -222,7 +222,7 @@ async fn main() {
             {
                 let mut compressor =
                     brotli::CompressorWriter::new(&mut compressed_data_bytes, 4096, 5, 22);
-                compressor.write_all(&data_bytes).unwrap();
+                compressor.write_all(data_bytes).unwrap();
             }
             compressed_data_bytes
         } else {

--- a/crates/websocket-proxy/src/main.rs
+++ b/crates/websocket-proxy/src/main.rs
@@ -18,6 +18,7 @@ use clap::Parser;
 use dotenvy::dotenv;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use rate_limit::RedisRateLimit;
+#[cfg(feature = "compression")]
 use std::io::Write;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -209,15 +210,22 @@ async fn main() {
             .active_connections
             .set((send.receiver_count() - 1) as f64);
 
-        let data_bytes = data.as_bytes();
-        let mut compressed_data_bytes = Vec::new();
-        {
-            let mut compressor =
-                brotli::CompressorWriter::new(&mut compressed_data_bytes, 4096, 5, 22);
-            compressor.write_all(&data_bytes).unwrap();
-        }
+        #[cfg(feature = "compression")]
+        let message_data = {
+            let data_bytes = data.as_bytes();
+            let mut compressed_data_bytes = Vec::new();
+            {
+                let mut compressor =
+                    brotli::CompressorWriter::new(&mut compressed_data_bytes, 4096, 5, 22);
+                compressor.write_all(&data_bytes).unwrap();
+            }
+            compressed_data_bytes
+        };
 
-        match send.send(compressed_data_bytes) {
+        #[cfg(not(feature = "compression"))]
+        let message_data = data.into_bytes();
+
+        match send.send(message_data) {
             Ok(_) => (),
             Err(e) => error!(message = "failed to send data", error = e.to_string()),
         }

--- a/crates/websocket-proxy/src/registry.rs
+++ b/crates/websocket-proxy/src/registry.rs
@@ -7,12 +7,12 @@ use tracing::{info, trace, warn};
 
 #[derive(Clone)]
 pub struct Registry {
-    sender: Sender<String>,
+    sender: Sender<Vec<u8>>,
     metrics: Arc<Metrics>,
 }
 
 impl Registry {
-    pub fn new(sender: Sender<String>, metrics: Arc<Metrics>) -> Self {
+    pub fn new(sender: Sender<Vec<u8>>, metrics: Arc<Metrics>) -> Self {
         Self { sender, metrics }
     }
 


### PR DESCRIPTION
The Websocket Proxy serves many downstream clients, and the raw JSON payload of the Flashblock stream adds up pretty quickly. Estimated monthly egress is quite high.

This PR introduces Brotli compression on the proxy level, giving us an average improvement of ~5.5-6x on the payload size tested against Base Sepolia. On Base Mainnet where blocks are larger, the difference is likely going to be even larger. 

Downstream clients (like Flashblocks aware preconf nodes) and direct WS consumers will need to implement decompression of the message before parsing it as JSON. 