### PR TITLE
Rollup-boost uses ping/pong to test the connection is open

### DIFF
--- a/crates/rollup-boost/src/flashblocks/inbound.rs
+++ b/crates/rollup-boost/src/flashblocks/inbound.rs
@@ -193,9 +193,7 @@ mod tests {
                                                         Some(Ok(Message::Ping(_))) => {
                                                             send_ping_tx.send(()).await.unwrap();
                                                         },
-                                                        _ => {
-                                                            println!("Received message: {:?}", msg);
-                                                        }
+                                                        _ => {}
                                                     }
                                                 }
                                                 _ = term_rx.changed() => {

--- a/crates/rollup-boost/src/flashblocks/inbound.rs
+++ b/crates/rollup-boost/src/flashblocks/inbound.rs
@@ -123,7 +123,7 @@ impl FlashblocksReceiverService {
                             sender
                                 .send(flashblocks_msg)
                                 .await
-                                .map_err(FlashblocksReceiverError::SendError)?;
+                                .map_err(|e| FlashblocksReceiverError::SendError(Box::new(e)))?;
                         }
                     }
                     Message::Close(_) => {

--- a/crates/rollup-boost/src/flashblocks/inbound.rs
+++ b/crates/rollup-boost/src/flashblocks/inbound.rs
@@ -28,7 +28,7 @@ enum FlashblocksReceiverError {
     TaskPanic(String),
 
     #[error("Failed to send message to sender: {0}")]
-    SendError(#[from] tokio::sync::mpsc::error::SendError<FlashblocksPayloadV1>),
+    SendError(#[from] Box<tokio::sync::mpsc::error::SendError<FlashblocksPayloadV1>>),
 }
 
 pub struct FlashblocksReceiverService {

--- a/crates/rollup-boost/src/flashblocks/inbound.rs
+++ b/crates/rollup-boost/src/flashblocks/inbound.rs
@@ -111,10 +111,10 @@ impl FlashblocksReceiverService {
                 match msg.unwrap() {
                     // TODO: handle errors
                     Message::Text(text) => {
+                        self.metrics.messages_received.increment(1);
                         if let Ok(flashblocks_msg) =
                             serde_json::from_str::<FlashblocksPayloadV1>(&text)
                         {
-                            self.metrics.messages_received.increment(1);
                             sender.send(flashblocks_msg).await.unwrap();
                         }
                     }

--- a/crates/rollup-boost/src/flashblocks/metrics.rs
+++ b/crates/rollup-boost/src/flashblocks/metrics.rs
@@ -1,7 +1,7 @@
 use metrics::{Counter, Gauge};
 use metrics_derive::Metrics;
 
-#[derive(Metrics)]
+#[derive(Metrics, Clone)]
 #[metrics(scope = "flashblocks.ws_inbound")]
 pub struct FlashblocksWsInboundMetrics {
     /// Total number of WebSocket reconnection attempts


### PR DESCRIPTION
This PR adds a ping/pong system over the Rollup-boost <-> Builder connection. The context of this PR is in #304.

The inbound websocket service will send ping messages to the builder if after some time interval x has not received any message from the builder. After sending the ping message, it will wait another n time duration to receive the pong message back.

The test still needs more work.