### PR TITLE
Fix flashblocks ping/pong intervals

### DIFF
--- a/crates/rollup-boost/Cargo.toml
+++ b/crates/rollup-boost/Cargo.toml
@@ -60,6 +60,7 @@ metrics-util = "0.19.0"
 paste = "1.0.15"
 parking_lot = "0.12.3"
 url = "2.2.0"
+tokio-util = { version = "0.7.13" }
 
 [dev-dependencies]
 rand = "0.9.0"


### PR DESCRIPTION
This PR fixes two issues with Flashblocks ping/pong protocol:
- The ping interval and the pong timeout have the same time duration (500ms) so it is really easy to timeout.
- The ping routine was not cleaned after a ping timeout so the websocket connection stays open and it does not get dropped.
