### PR TITLE
Use the L2 client to compute builder's payload's state root 

### DIFF
--- a/crates/rollup-boost/src/cli.rs
+++ b/crates/rollup-boost/src/cli.rs
@@ -98,7 +98,7 @@ pub struct Args {
     pub block_selection_policy: Option<BlockSelectionPolicy>,
 
     /// Should we use the l2 client for computing state root
-    #[arg(long, env, default_value = "true")]
+    #[arg(long, env, default_value = "false")]
     pub use_l2_client_for_state_root: bool,
 
     #[clap(flatten)]

--- a/crates/rollup-boost/src/cli.rs
+++ b/crates/rollup-boost/src/cli.rs
@@ -97,6 +97,10 @@ pub struct Args {
     #[arg(long, env)]
     pub block_selection_policy: Option<BlockSelectionPolicy>,
 
+    /// Should we use the l2 client for computing state root
+    #[arg(long, env, default_value = "true")]
+    pub use_l2_client_for_state_root: bool,
+
     #[clap(flatten)]
     pub flashblocks: FlashblocksArgs,
 }
@@ -191,6 +195,7 @@ impl Args {
             execution_mode.clone(),
             self.block_selection_policy,
             probes.clone(),
+            self.use_l2_client_for_state_root,
         );
 
         let health_handle =

--- a/crates/rollup-boost/src/payload.rs
+++ b/crates/rollup-boost/src/payload.rs
@@ -3,7 +3,7 @@ use alloy_primitives::{B256, Bytes, keccak256};
 use futures::{StreamExt as _, stream};
 use moka::future::Cache;
 
-use alloy_rpc_types_engine::{ExecutionPayload, ExecutionPayloadV3, PayloadId};
+use alloy_rpc_types_engine::{ExecutionPayload, ExecutionPayloadV3, PayloadAttributes, PayloadId};
 use op_alloy_rpc_types_engine::{
     OpExecutionPayloadEnvelopeV3, OpExecutionPayloadEnvelopeV4, OpExecutionPayloadV4,
     OpPayloadAttributes,
@@ -61,6 +61,77 @@ impl OpExecutionPayloadEnvelope {
                 .payload_inner
                 .transactions
                 .len(),
+        }
+    }
+
+    pub fn transactions(&self) -> Vec<Bytes> {
+        match self {
+            OpExecutionPayloadEnvelope::V3(payload) => payload
+                .execution_payload
+                .payload_inner
+                .payload_inner
+                .transactions
+                .clone(),
+            OpExecutionPayloadEnvelope::V4(payload) => payload
+                .execution_payload
+                .payload_inner
+                .payload_inner
+                .payload_inner
+                .transactions
+                .clone(),
+        }
+    }
+
+    pub fn payload_attributes(&self) -> PayloadAttributes {
+        match self {
+            OpExecutionPayloadEnvelope::V3(payload) => PayloadAttributes {
+                timestamp: payload
+                    .execution_payload
+                    .payload_inner
+                    .payload_inner
+                    .timestamp,
+                prev_randao: payload
+                    .execution_payload
+                    .payload_inner
+                    .payload_inner
+                    .prev_randao,
+                suggested_fee_recipient: payload
+                    .execution_payload
+                    .payload_inner
+                    .payload_inner
+                    .fee_recipient,
+                withdrawals: Some(payload.execution_payload.payload_inner.withdrawals.clone()),
+                parent_beacon_block_root: Some(payload.parent_beacon_block_root),
+            },
+            OpExecutionPayloadEnvelope::V4(payload) => PayloadAttributes {
+                timestamp: payload
+                    .execution_payload
+                    .payload_inner
+                    .payload_inner
+                    .payload_inner
+                    .timestamp,
+                prev_randao: payload
+                    .execution_payload
+                    .payload_inner
+                    .payload_inner
+                    .payload_inner
+                    .prev_randao,
+                suggested_fee_recipient: payload
+                    .execution_payload
+                    .payload_inner
+                    .payload_inner
+                    .payload_inner
+                    .fee_recipient,
+                withdrawals: Some(
+                    payload
+                        .execution_payload
+                        .payload_inner
+                        .payload_inner
+                        .withdrawals
+                        .clone(),
+                ),
+                parent_beacon_block_root: Some(payload.parent_beacon_block_root),
+            },
         }
     }
 }

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -193,6 +193,11 @@ impl RollupBoostServer {
             let payload = self.builder_client.get_payload(payload_id, version).await?;
 
             if self.use_l2_client_for_state_root == false {
+                let _ = self
+                    .l2_client
+                    .new_payload(NewPayload::from(payload.clone()))
+                    .await?;
+
                 return Ok(Some(payload));
             }
 

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -319,6 +319,7 @@ impl RollupBoostServer {
         let inner_payload = ExecutionPayload::from(payload.clone());
         let block_hash = inner_payload.block_hash();
         let block_number = inner_payload.block_number();
+        let state_root = inner_payload.as_v1().state_root;
 
         // Note: This log message is used by integration tests to track payload context.
         // While not ideal to rely on log parsing, it provides a reliable way to verify behavior.
@@ -327,6 +328,7 @@ impl RollupBoostServer {
             message = "returning block",
             "hash" = %block_hash,
             "number" = %block_number,
+            "state_root" = %state_root,
             %context,
             %payload_id,
         );

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -1010,7 +1010,7 @@ pub mod tests {
         assert!(fcu_response.is_ok());
 
         // wait for builder to observe the FCU call
-        sleep(std::time::Duration::from_millis(10)).await;
+        sleep(std::time::Duration::from_millis(100)).await;
 
         {
             let builder_fcu_req = builder_mock.fcu_requests.lock();

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -210,24 +210,13 @@ impl RollupBoostServer {
                 .clone();
 
             let new_payload_attrs = match fcu_info.1.as_ref() {
-                Some(attrs) => {
-                    let transactions = match &attrs.transactions {
-                        Some(txns) => {
-                            let mut final_txns = txns.clone();
-                            final_txns.extend(payload.transactions());
-                            final_txns
-                        }
-                        None => payload.transactions().clone(),
-                    };
-
-                    OpPayloadAttributes {
-                        payload_attributes: attrs.payload_attributes.clone(),
-                        transactions: Some(transactions),
-                        no_tx_pool: Some(true),
-                        gas_limit: attrs.gas_limit,
-                        eip_1559_params: attrs.eip_1559_params,
-                    }
-                }
+                Some(attrs) => OpPayloadAttributes {
+                    payload_attributes: attrs.payload_attributes.clone(),
+                    transactions: Some(payload.transactions()),
+                    no_tx_pool: Some(true),
+                    gas_limit: attrs.gas_limit,
+                    eip_1559_params: attrs.eip_1559_params,
+                },
                 None => OpPayloadAttributes {
                     payload_attributes: payload.payload_attributes(),
                     transactions: Some(payload.transactions()),

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -231,18 +231,18 @@ impl RollupBoostServer {
                     "returned_payload_id" = %new_payload_id,
                     "old_payload_id" = %payload_id,
                 );
-                let v3 = self
+                let l2_payload = self
                     .l2_client
                     .get_payload(new_payload_id, PayloadVersion::V4)
                     .await;
 
-                match v3 {
-                    Ok(v3) => {
+                match l2_payload {
+                    Ok(new_payload) => {
                         debug!(
                             message = "received new state root payload from l2",
-                            payload = ?v3,
+                            payload = ?new_payload,
                         );
-                        return Ok(Some(v3));
+                        return Ok(Some(new_payload));
                     }
 
                     Err(e) => {

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -138,12 +138,12 @@ impl RollupBoostServer {
         payload_id: PayloadId,
         version: PayloadVersion,
     ) -> RpcResult<OpExecutionPayloadEnvelope> {
-        let l2_payload = self.l2_client.get_payload(payload_id, version).await;
+        let l2_fut = self.l2_client.get_payload(payload_id, version);
 
         // If execution mode is disabled, return the l2 payload without sending
         // the request to the builder
         if self.execution_mode().is_disabled() {
-            return match l2_payload {
+            return match l2_fut.await {
                 Ok(payload) => {
                     self.probes.set_health(Health::Healthy);
                     let context = PayloadSource::L2;
@@ -268,7 +268,7 @@ impl RollupBoostServer {
             Ok(None)
         };
 
-        let builder_payload = builder_fut.await;
+        let (l2_payload, builder_payload) = tokio::join!(l2_fut, builder_fut);
 
         // Evaluate the builder and l2 response and select the final payload
         let (payload, context) = {

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -210,13 +210,24 @@ impl RollupBoostServer {
                 .clone();
 
             let new_payload_attrs = match fcu_info.1.as_ref() {
-                Some(attrs) => OpPayloadAttributes {
-                    payload_attributes: attrs.payload_attributes.clone(),
-                    transactions: Some(payload.transactions()),
-                    no_tx_pool: Some(true),
-                    gas_limit: attrs.gas_limit,
-                    eip_1559_params: attrs.eip_1559_params,
-                },
+                Some(attrs) => {
+                    let transactions = match &attrs.transactions {
+                        Some(txns) => {
+                            let mut final_txns = txns.clone();
+                            final_txns.extend(payload.transactions());
+                            final_txns
+                        }
+                        None => payload.transactions().clone(),
+                    };
+
+                    OpPayloadAttributes {
+                        payload_attributes: attrs.payload_attributes.clone(),
+                        transactions: Some(transactions),
+                        no_tx_pool: Some(true),
+                        gas_limit: attrs.gas_limit,
+                        eip_1559_params: attrs.eip_1559_params,
+                    }
+                }
                 None => OpPayloadAttributes {
                     payload_attributes: payload.payload_attributes(),
                     transactions: Some(payload.transactions()),
@@ -236,10 +247,7 @@ impl RollupBoostServer {
                     "returned_payload_id" = %new_payload_id,
                     "old_payload_id" = %payload_id,
                 );
-                let l2_payload = self
-                    .l2_client
-                    .get_payload(new_payload_id, PayloadVersion::V4)
-                    .await;
+                let l2_payload = self.l2_client.get_payload(new_payload_id, version).await;
 
                 match l2_payload {
                     Ok(new_payload) => {

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -445,16 +445,6 @@ impl EngineApiServer for RollupBoostServer {
                 // We always return the value from the l2 client
                 return Ok(l2_response);
             } else {
-                let current_timestamp = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs();
-                let is_historical_syncing = attrs.payload_attributes.timestamp < current_timestamp;
-                if is_historical_syncing {
-                    info!(message = "historical syncing FCU received. skipping FCU to builder");
-                    return Ok(l2_fut.await?);
-                }
-
                 // If the tx pool is enabled, forward the fcu
                 // to both the builder and the default l2 client
                 let builder_fut = self

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -746,7 +746,7 @@ pub mod tests {
                 execution_mode.clone(),
                 None,
                 probes.clone(),
-                true,
+                false,
             );
 
             let module: RpcModule<()> = rollup_boost.try_into().unwrap();

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -226,7 +226,7 @@ impl RollupBoostServer {
             if let Some(new_payload_id) = l2_result.payload_id {
                 let v3 = self
                     .l2_client
-                    .get_payload(new_payload_id, PayloadVersion::V3)
+                    .get_payload(new_payload_id, PayloadVersion::V4)
                     .await?;
 
                 return Ok(Some(v3));

--- a/crates/rollup-boost/src/tests/common/mod.rs
+++ b/crates/rollup-boost/src/tests/common/mod.rs
@@ -231,6 +231,7 @@ pub struct RollupBoostTestHarnessBuilder {
     proxy_handler: Option<Arc<dyn BuilderProxyHandler>>,
     isthmus_block: Option<u64>,
     block_time: u64,
+    use_l2_client_for_state_root: bool,
 }
 
 impl RollupBoostTestHarnessBuilder {
@@ -240,6 +241,7 @@ impl RollupBoostTestHarnessBuilder {
             proxy_handler: None,
             isthmus_block: None,
             block_time: 1,
+            use_l2_client_for_state_root: false,
         }
     }
 
@@ -287,6 +289,11 @@ impl RollupBoostTestHarnessBuilder {
 
     pub fn proxy_handler(mut self, proxy_handler: Arc<dyn BuilderProxyHandler>) -> Self {
         self.proxy_handler = Some(proxy_handler);
+        self
+    }
+
+    pub fn with_l2_state_root_computation(mut self, enabled: bool) -> Self {
+        self.use_l2_client_for_state_root = enabled;
         self
     }
 
@@ -363,7 +370,7 @@ impl RollupBoostTestHarnessBuilder {
         rollup_boost.args.l2_client.l2_url = l2.auth_rpc().await?;
         rollup_boost.args.builder.builder_url = builder_url.try_into().unwrap();
         rollup_boost.args.log_file = Some(rollup_boost_log_file_path);
-        rollup_boost.args.use_l2_client_for_state_root = false;
+        rollup_boost.args.use_l2_client_for_state_root = self.use_l2_client_for_state_root;
         let rollup_boost = rollup_boost.start().await;
         println!("rollup-boost authrpc: {}", rollup_boost.rpc_endpoint());
         println!("rollup-boost metrics: {}", rollup_boost.metrics_endpoint());

--- a/crates/rollup-boost/src/tests/common/mod.rs
+++ b/crates/rollup-boost/src/tests/common/mod.rs
@@ -363,6 +363,7 @@ impl RollupBoostTestHarnessBuilder {
         rollup_boost.args.l2_client.l2_url = l2.auth_rpc().await?;
         rollup_boost.args.builder.builder_url = builder_url.try_into().unwrap();
         rollup_boost.args.log_file = Some(rollup_boost_log_file_path);
+        rollup_boost.args.use_l2_client_for_state_root = false;
         let rollup_boost = rollup_boost.start().await;
         println!("rollup-boost authrpc: {}", rollup_boost.rpc_endpoint());
         println!("rollup-boost metrics: {}", rollup_boost.metrics_endpoint());

--- a/crates/rollup-boost/src/tests/l2_state_root_computation.rs
+++ b/crates/rollup-boost/src/tests/l2_state_root_computation.rs
@@ -1,0 +1,75 @@
+use std::{pin::Pin, sync::Arc};
+
+use super::common::{RollupBoostTestHarnessBuilder, proxy::BuilderProxyHandler};
+use alloy_primitives::B256;
+use futures::FutureExt as _;
+use serde_json::Value;
+
+use op_alloy_rpc_types_engine::OpExecutionPayloadEnvelopeV3;
+
+struct ZeroStateRootHandler;
+
+impl BuilderProxyHandler for ZeroStateRootHandler {
+    fn handle(
+        &self,
+        method: String,
+        _params: Value,
+        _result: Value,
+    ) -> Pin<Box<dyn Future<Output = Option<Value>> + Send>> {
+        async move {
+            if method != "engine_getPayloadV3" {
+                return None;
+            }
+
+            let mut payload =
+                serde_json::from_value::<OpExecutionPayloadEnvelopeV3>(_result).unwrap();
+
+            // Set state root to zero to simulate builder payload without computed state root
+            payload
+                .execution_payload
+                .payload_inner
+                .payload_inner
+                .state_root = B256::ZERO;
+
+            let result = serde_json::to_value(&payload).unwrap();
+            Some(result)
+        }
+        .boxed()
+    }
+}
+
+#[tokio::test]
+async fn test_l2_state_root_computation() -> eyre::Result<()> {
+    // Test that when builder returns payload with zero state root and L2 state root computation
+    // is enabled, rollup-boost uses L2 client to compute the correct state root
+    let harness = RollupBoostTestHarnessBuilder::new("l2_state_root_computation")
+        .proxy_handler(Arc::new(ZeroStateRootHandler))
+        .with_l2_state_root_computation(true)
+        .build()
+        .await?;
+
+    let mut block_generator = harness.block_generator().await?;
+
+    // Generate blocks and verify they are processed successfully by the builder
+    // with L2 computing the correct state root
+    for _ in 0..3 {
+        let (_block, block_creator) = block_generator.generate_block(false).await?;
+        assert!(
+            block_creator.is_builder(),
+            "Block creator should be the builder"
+        );
+    }
+
+    // Check logs to verify L2 state root computation was used
+    let logs = std::fs::read_to_string(harness.rollup_boost.args().log_file.clone().unwrap())?;
+    assert!(
+        logs.contains("sent FCU to l2 to calculate new state root"),
+        "Logs should contain message indicating L2 state root computation was used"
+    );
+    assert!(
+        logs.contains("received new state root payload from l2"),
+        "Logs should contain message indicating L2 returned corrected payload"
+    );
+
+    Ok(())
+}

--- a/crates/rollup-boost/src/tests/mod.rs
+++ b/crates/rollup-boost/src/tests/mod.rs
@@ -4,6 +4,7 @@ mod builder_full_delay;
 mod builder_returns_incorrect_block;
 mod execution_mode;
 mod fcu_no_block_time_delay;
+mod l2_state_root_computation;
 mod no_tx_pool;
 mod remote_builder_down;
 mod simple;


### PR DESCRIPTION
Adds a flag that assumes that the state root of the payload coming from the builder isn't correct, and has the l2 client recompute the state root via a combination of a new FCU + getPayload request to the l2 client while loading the builder's payload

This change is accompanied by a similar PR coming soon in `op-rbuilder` which adds a flag where the builder doesn't concern itself with state root computation at all and instead just sets `state_root = B256::ZERO`

The context here is that state root computation per flashblock is extremely slow, and there are concerns if we can launch on Base Mainnet and still produce flashblocks every 200ms with that. By disabling that computation in the builder, and instead having rollup boost use the L2 Client to recompute the state root, we get around that problem by introducing a minor overhead in the `getPayload` request to rollup boost.

(sorry about the bad commit messages, it was a lot of hacky stuff initially)