### PR TITLE
Parametrise Dockerfile to build debug binaries

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,4 +1,4 @@
-devnet-up: build spawn
+devnet-up: build-debug spawn
 
 devnet-down:
     kurtosis enclave rm -f op-rollup-boost

--- a/Justfile
+++ b/Justfile
@@ -8,8 +8,13 @@ stress-test:
     chmod +x ./scripts/ci/stress.sh \
         && ./scripts/ci/stress.sh run
 
+# Build docker image (release)
 build:
-    docker buildx build -t flashbots/rollup-boost:develop .
+    docker buildx build --build-arg RELEASE=true -t flashbots/rollup-boost:develop .
+
+# Build docker image (debug)
+build-debug:
+    docker buildx build --build-arg RELEASE=false -t flashbots/rollup-boost:develop .
 
 spawn:
     kurtosis run github.com/ethpandaops/optimism-package --args-file ./scripts/ci/kurtosis-params.yaml --enclave op-rollup-boost


### PR DESCRIPTION
Closes #338. The docker in debug mode takes 5m to build vs release mode that takes 11m.