### PR TITLE
fix: correct git sha in user agent

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,9 @@
 # Version control
-.git
 .github
 .gitignore
+
+# Include for vergen constants
+!/.git
 
 # Build artifacts
 **/target

--- a/crates/rollup-boost/build.rs
+++ b/crates/rollup-boost/build.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     emitter.emit_and_set()?;
     let sha = env::var("VERGEN_GIT_SHA")?;
-    let sha_short = &sha[0..7];
+    let sha_short = &sha[0..8];
 
     // Set short SHA
     println!("cargo:rustc-env=VERGEN_GIT_SHA_SHORT={}", &sha_short);


### PR DESCRIPTION
Previously the user agent looked like "0.1.0-VERGEN_" (https://github.com/flashbots/rollup-boost/pull/308#issuecomment-2968125653). Now it should look something like "0.1.0-4e3fb849" (concatenation of the cargo version and the git sha).