### PR TITLE
feat: use generics for builder client  

### DIFF
--- a/crates/rollup-boost/src/cli.rs
+++ b/crates/rollup-boost/src/cli.rs
@@ -13,8 +13,8 @@ use tokio::signal::unix::{SignalKind, signal as unix_signal};
 use tracing::{Level, info};
 
 use crate::{
-    BlockSelectionPolicy, DebugClient, EngineApiExt, Flashblocks, FlashblocksArgs, ProxyLayer,
-    RollupBoostServer, RpcClient,
+    BlockSelectionPolicy, DebugClient, Flashblocks, FlashblocksArgs, ProxyLayer, RollupBoostServer,
+    RpcClient,
     client::rpc::{BuilderArgs, L2ClientArgs},
     debug_api::ExecutionMode,
     get_version, init_metrics,

--- a/crates/rollup-boost/src/cli.rs
+++ b/crates/rollup-boost/src/cli.rs
@@ -166,40 +166,52 @@ impl Args {
         )?;
 
         let (probe_layer, probes) = ProbeLayer::new();
+        let execution_mode = Arc::new(Mutex::new(self.execution_mode));
 
-        let builder_client: Arc<dyn EngineApiExt> = if self.flashblocks.flashblocks {
+        let (rpc_module, health_handle): (RpcModule<()>, _) = if self.flashblocks.flashblocks {
             let inbound_url = self.flashblocks.flashblocks_builder_url;
             let outbound_addr = SocketAddr::new(
                 IpAddr::from_str(&self.flashblocks.flashblocks_host)?,
                 self.flashblocks.flashblocks_port,
             );
 
-            Arc::new(Flashblocks::run(
+            let builder_client = Arc::new(Flashblocks::run(
                 builder_client.clone(),
                 inbound_url,
                 outbound_addr,
                 self.flashblocks.flashblock_builder_ws_reconnect_ms,
-            )?)
+            )?);
+
+            let rollup_boost = RollupBoostServer::new(
+                l2_client,
+                builder_client,
+                execution_mode.clone(),
+                self.block_selection_policy,
+                probes.clone(),
+            );
+
+            let health_handle = rollup_boost
+                .spawn_health_check(self.health_check_interval, self.max_unsafe_interval);
+
+            // Spawn the debug server
+            rollup_boost.start_debug_server(debug_addr.as_str()).await?;
+            (rollup_boost.try_into()?, health_handle)
         } else {
-            Arc::new(builder_client)
+            let rollup_boost = RollupBoostServer::new(
+                l2_client,
+                Arc::new(builder_client),
+                execution_mode.clone(),
+                self.block_selection_policy,
+                probes.clone(),
+            );
+
+            let health_handle = rollup_boost
+                .spawn_health_check(self.health_check_interval, self.max_unsafe_interval);
+
+            // Spawn the debug server
+            rollup_boost.start_debug_server(debug_addr.as_str()).await?;
+            (rollup_boost.try_into()?, health_handle)
         };
-
-        let execution_mode = Arc::new(Mutex::new(self.execution_mode));
-        let rollup_boost = RollupBoostServer::new(
-            l2_client,
-            builder_client,
-            execution_mode.clone(),
-            self.block_selection_policy,
-            probes.clone(),
-        );
-
-        let health_handle =
-            rollup_boost.spawn_health_check(self.health_check_interval, self.max_unsafe_interval);
-
-        // Spawn the debug server
-        rollup_boost.start_debug_server(debug_addr.as_str()).await?;
-
-        let module: RpcModule<()> = rollup_boost.try_into()?;
 
         // Build and start the server
         info!("Starting server on :{}", self.rpc_port);
@@ -216,11 +228,12 @@ impl Args {
                     builder_args.builder_timeout,
                 ));
 
+        // NOTE: clean this up
         let server = Server::builder()
             .set_http_middleware(http_middleware)
             .build(format!("{}:{}", self.rpc_host, self.rpc_port).parse::<SocketAddr>()?)
             .await?;
-        let handle = server.start(module);
+        let handle = server.start(rpc_module);
 
         let stop_handle = handle.clone();
 

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -44,19 +44,22 @@ pub type BufferedRequest = http::Request<Full<bytes::Bytes>>;
 pub type BufferedResponse = http::Response<Full<bytes::Bytes>>;
 
 #[derive(Clone)]
-pub struct RollupBoostServer {
+pub struct RollupBoostServer<T: EngineApiExt> {
     pub l2_client: Arc<RpcClient>,
-    pub builder_client: Arc<dyn EngineApiExt>,
+    pub builder_client: Arc<T>,
     pub payload_trace_context: Arc<PayloadTraceContext>,
     block_selection_policy: Option<BlockSelectionPolicy>,
     execution_mode: Arc<Mutex<ExecutionMode>>,
     probes: Arc<Probes>,
 }
 
-impl RollupBoostServer {
+impl<T> RollupBoostServer<T>
+where
+    T: EngineApiExt,
+{
     pub fn new(
         l2_client: RpcClient,
-        builder_client: Arc<dyn EngineApiExt>,
+        builder_client: Arc<T>,
         initial_execution_mode: Arc<Mutex<ExecutionMode>>,
         block_selection_policy: Option<BlockSelectionPolicy>,
         probes: Arc<Probes>,
@@ -264,7 +267,10 @@ impl RollupBoostServer {
     }
 }
 
-impl TryInto<RpcModule<()>> for RollupBoostServer {
+impl<T> TryInto<RpcModule<()>> for RollupBoostServer<T>
+where
+    T: EngineApiExt,
+{
     type Error = RegisterMethodError;
 
     fn try_into(self) -> Result<RpcModule<()>, Self::Error> {
@@ -322,7 +328,10 @@ pub trait EngineApi {
 }
 
 #[async_trait]
-impl EngineApiServer for RollupBoostServer {
+impl<T> EngineApiServer for RollupBoostServer<T>
+where
+    T: EngineApiExt,
+{
     #[instrument(
         skip_all,
         err,


### PR DESCRIPTION
This PR updates `RollupBoostServer` to use generics for `builder_client` instead of `dyn EngineApiExt`. Replacing dynamic dispatch with a concrete generic type removes the runtime cost of vtable lookups and heap allocation, enabling the compiler to use static dispatch instead.