### PR TITLE
Pin Kurtosis

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -12,4 +12,5 @@ build:
     docker buildx build -t flashbots/rollup-boost:develop .
 
 spawn:
-    kurtosis run github.com/ethpandaops/optimism-package --args-file ./scripts/ci/kurtosis-params.yaml --enclave op-rollup-boost
+    # Pinning to this commit until https://github.com/ethpandaops/optimism-package/issues/349 is fixed
+    kurtosis run github.com/ethpandaops/optimism-package@452133367b693e3ba22214a6615c86c60a1efd5e --args-file ./scripts/ci/kurtosis-params.yaml --enclave op-rollup-boost


### PR DESCRIPTION
There is an ongoing refactor of the Optimism Kurtosis package and we have already updated at least in three occasions the spec. Right now, with the latest changes the chain does not advance, ref https://github.com/ethpandaops/optimism-package/issues/349.

This PR pins for the short term the Kurtosis spec to a version that is funtional.
