### PR TITLE
chore: simplify `rollup-boost` args

### DIFF
--- a/crates/rollup-boost/src/bin/main.rs
+++ b/crates/rollup-boost/src/bin/main.rs
@@ -1,14 +1,13 @@
 use clap::Parser;
-use rollup_boost::Args;
-use rollup_boost::init_tracing;
-
 use dotenvy::dotenv;
+use rollup_boost::RollupBoostArgs;
+use rollup_boost::init_tracing;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
     dotenv().ok();
 
-    let args = Args::parse();
+    let args = RollupBoostArgs::parse();
     init_tracing(&args)?;
     args.run().await
 }

--- a/crates/rollup-boost/src/cli.rs
+++ b/crates/rollup-boost/src/cli.rs
@@ -200,7 +200,6 @@ impl RollupBoostArgs {
                     builder_args.builder_timeout,
                 ));
 
-        // NOTE: clean this up
         let server = Server::builder()
             .set_http_middleware(http_middleware)
             .build(format!("{}:{}", self.rpc_host, self.rpc_port).parse::<SocketAddr>()?)

--- a/crates/rollup-boost/src/debug_api.rs
+++ b/crates/rollup-boost/src/debug_api.rs
@@ -47,7 +47,7 @@ pub struct GetExecutionModeResponse {
 }
 
 #[rpc(server, client, namespace = "debug")]
-trait DebugApi {
+pub trait DebugApi {
     #[method(name = "setExecutionMode")]
     async fn set_execution_mode(
         &self,

--- a/crates/rollup-boost/src/flashblocks/args.rs
+++ b/crates/rollup-boost/src/flashblocks/args.rs
@@ -3,10 +3,6 @@ use url::Url;
 
 #[derive(Parser, Clone, Debug)]
 pub struct FlashblocksArgs {
-    /// Enable Flashblocks client
-    #[arg(long, env, default_value = "false")]
-    pub flashblocks: bool,
-
     /// Flashblocks Builder WebSocket URL
     #[arg(long, env, default_value = "ws://127.0.0.1:1111")]
     pub flashblocks_builder_url: Url,

--- a/crates/rollup-boost/src/metrics.rs
+++ b/crates/rollup-boost/src/metrics.rs
@@ -13,9 +13,9 @@ use hyper_util::rt::TokioIo;
 use jsonrpsee::http_client::HttpBody;
 use metrics_exporter_prometheus::PrometheusHandle;
 
-use crate::cli::Args;
+use crate::cli::RollupBoostArgs;
 
-pub fn init_metrics(args: &Args) -> Result<()> {
+pub fn init_metrics(args: &RollupBoostArgs) -> Result<()> {
     if args.metrics {
         let recorder = PrometheusBuilder::new().build_recorder();
         let handle = recorder.handle();

--- a/crates/rollup-boost/src/tests/common/services/rollup_boost.rs
+++ b/crates/rollup-boost/src/tests/common/services/rollup_boost.rs
@@ -1,6 +1,6 @@
 use std::{fs::File, time::Duration};
 
-use crate::Args;
+use crate::RollupBoostArgs;
 use clap::Parser;
 use tokio::task::JoinHandle;
 use tracing::subscriber::DefaultGuard;
@@ -10,13 +10,13 @@ use crate::tests::common::{TEST_DATA, get_available_port};
 
 #[derive(Debug)]
 pub struct RollupBoost {
-    args: Args,
+    args: RollupBoostArgs,
     pub _handle: JoinHandle<eyre::Result<()>>,
     pub _tracing_guard: DefaultGuard,
 }
 
 impl RollupBoost {
-    pub fn args(&self) -> &Args {
+    pub fn args(&self) -> &RollupBoostArgs {
         &self.args
     }
 
@@ -41,12 +41,12 @@ impl RollupBoost {
 
 #[derive(Clone, Debug)]
 pub struct RollupBoostConfig {
-    pub args: Args,
+    pub args: RollupBoostArgs,
 }
 
 impl Default for RollupBoostConfig {
     fn default() -> Self {
-        let mut args = Args::parse_from([
+        let mut args = RollupBoostArgs::parse_from([
             "rollup-boost",
             &format!("--l2-jwt-path={}/jwt_secret.hex", *TEST_DATA),
             &format!("--builder-jwt-path={}/jwt_secret.hex", *TEST_DATA),

--- a/crates/rollup-boost/src/tracing.rs
+++ b/crates/rollup-boost/src/tracing.rs
@@ -12,7 +12,7 @@ use tracing_subscriber::filter::Targets;
 use tracing_subscriber::fmt::writer::BoxMakeWriter;
 use tracing_subscriber::layer::SubscriberExt;
 
-use crate::cli::{Args, LogFormat};
+use crate::cli::{LogFormat, RollupBoostArgs};
 
 /// Span attribute keys that should be recorded as metric labels.
 ///
@@ -99,7 +99,7 @@ impl SpanProcessor for MetricsSpanProcessor {
     }
 }
 
-pub fn init_tracing(args: &Args) -> eyre::Result<()> {
+pub fn init_tracing(args: &RollupBoostArgs) -> eyre::Result<()> {
     // Be cautious with snake_case and kebab-case here
     let filter_name = "rollup_boost".to_string();
 


### PR DESCRIPTION
This PR cleans up the CLI args structure to improve ergonomics and remove redundant logic:

- Remove the `Commands` subcommand and debug commands. This command seems to be redundant since the debug API is already exposed over HTTP. This also created potential inconsistencies where `execution_mode` could be set via CLI flags but then overridden separately via debug commands.
- Remove the `--flashblocks` boolean flag. Instead, Flashblocks configuration is now optional via `Option<FlashblocksArgs>`. Flashblocks is enabled if any related `--flashblocks-*` flags are specified.
- Rename `Args` to `RollupBoostArgs` for clarity and consistency.