### PR TITLE
feat: add client ping/pong health checks

### DIFF
--- a/crates/websocket-proxy/src/client.rs
+++ b/crates/websocket-proxy/src/client.rs
@@ -1,6 +1,5 @@
 use crate::rate_limit::Ticket;
 use axum::extract::ws::WebSocket;
-use axum::Error;
 use std::net::IpAddr;
 
 pub struct ClientConnection {
@@ -16,10 +15,6 @@ impl ClientConnection {
             _ticket: ticket,
             websocket,
         }
-    }
-
-    pub async fn send(&mut self, data: Vec<u8>) -> Result<(), Error> {
-        self.websocket.send(data.into()).await
     }
 
     pub fn id(&self) -> String {

--- a/crates/websocket-proxy/src/registry.rs
+++ b/crates/websocket-proxy/src/registry.rs
@@ -1,61 +1,156 @@
 use crate::client::ClientConnection;
 use crate::metrics::Metrics;
+use axum::extract::ws::Message;
+use futures::stream::StreamExt;
+use futures::SinkExt;
 use std::sync::Arc;
+use std::time::Instant;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::broadcast::Sender;
-use tracing::{info, trace, warn};
+use tokio::time::{interval, Duration};
+use tracing::{debug, info, trace, warn};
 
 #[derive(Clone)]
 pub struct Registry {
-    sender: Sender<Vec<u8>>,
+    sender: Sender<Message>,
     metrics: Arc<Metrics>,
+    ping_enabled: bool,
+    pong_timeout_ms: u64,
 }
 
 impl Registry {
-    pub fn new(sender: Sender<Vec<u8>>, metrics: Arc<Metrics>) -> Self {
-        Self { sender, metrics }
+    pub fn new(
+        sender: Sender<Message>,
+        metrics: Arc<Metrics>,
+        ping_enabled: bool,
+        pong_timeout_ms: u64,
+    ) -> Self {
+        Self {
+            sender,
+            metrics,
+            ping_enabled,
+            pong_timeout_ms,
+        }
     }
 
-    pub async fn subscribe(&self, mut client: ClientConnection) {
+    pub async fn subscribe(&self, client: ClientConnection) {
         info!(message = "subscribing client", client = client.id());
 
         let mut receiver = self.sender.subscribe();
         let metrics = self.metrics.clone();
         metrics.new_connections.increment(1);
 
-        tokio::spawn(async move {
-            loop {
-                match receiver.recv().await {
-                    Ok(msg) => match client.send(msg.clone()).await {
-                        Ok(_) => {
-                            trace!(message = "message sent to client", client = client.id());
-                            metrics.sent_messages.increment(1);
-                            metrics.bytes_broadcasted.increment(msg.len() as u64);
+        let client_id = client.id();
+        let (mut ws_sender, ws_receiver) = client.websocket.split();
+
+        let (disconnect_client_tx, mut disconnect_client_rx) = tokio::sync::oneshot::channel();
+        let client_reader = self.start_reader(ws_receiver, client_id.clone(), disconnect_client_tx);
+
+        loop {
+            tokio::select! {
+                broadcast_result = receiver.recv() => {
+                    match broadcast_result {
+                        Ok(msg) => {
+                            if let Err(e) = ws_sender.send(msg.clone()).await {
+                                warn!(
+                                    message = "failed to send data to client",
+                                    client = client_id,
+                                    error = e.to_string()
+                                );
+                                metrics.failed_messages.increment(1);
+                                break;
+                            }
+                            trace!(message = "message sent to client", client = client_id);
+                            metrics.record_message_sent(&msg);
                         }
-                        Err(e) => {
-                            warn!(
-                                message = "failed to send data to client",
-                                client = client.id(),
-                                error = e.to_string()
-                            );
-                            metrics.failed_messages.increment(1);
+                        Err(RecvError::Closed) => {
+                            info!(message = "upstream connection closed", client = client_id);
                             break;
                         }
-                    },
-                    Err(RecvError::Closed) => {
-                        info!(message = "upstream connection closed", client = client.id());
-                        break;
+                        Err(RecvError::Lagged(_)) => {
+                            info!(message = "client is lagging", client = client_id);
+                            metrics.lagged_connections.increment(1);
+                            break;
+                        }
                     }
-                    Err(RecvError::Lagged(_)) => {
-                        info!(message = "client is lagging", client = client.id());
-                        metrics.lagged_connections.increment(1);
-                        break;
+                }
+
+                _ = &mut disconnect_client_rx => {
+                    debug!(message = "client reader signaled disconnect", client = client_id);
+                    break;
+                }
+            }
+        }
+
+        client_reader.abort();
+        metrics.closed_connections.increment(1);
+
+        info!(message = "client disconnected", client = client_id);
+    }
+
+    fn start_reader(
+        &self,
+        ws_receiver: futures::stream::SplitStream<axum::extract::ws::WebSocket>,
+        client_id: String,
+        disconnect_client_tx: tokio::sync::oneshot::Sender<()>,
+    ) -> tokio::task::JoinHandle<()> {
+        let ping_enabled = self.ping_enabled;
+        let pong_timeout_ms = self.pong_timeout_ms;
+        let metrics = self.metrics.clone();
+
+        tokio::spawn(async move {
+            let mut ws_receiver = ws_receiver;
+            let mut last_pong = Instant::now();
+            let mut timeout_checker = interval(Duration::from_millis(pong_timeout_ms / 4));
+            let pong_timeout = Duration::from_millis(pong_timeout_ms);
+
+            loop {
+                tokio::select! {
+                    msg = ws_receiver.next() => {
+                        match msg {
+                            Some(Ok(Message::Pong(_))) => {
+                                if ping_enabled {
+                                    trace!(message = "received pong from client", client = client_id);
+                                    last_pong = Instant::now();
+                                }
+                            }
+                            Some(Ok(Message::Close(_))) => {
+                                trace!(message = "received close from client", client = client_id);
+                                let _ = disconnect_client_tx.send(());
+                                return;
+                            }
+                            Some(Err(e)) => {
+                                trace!(
+                                    message = "error receiving from client",
+                                    client = client_id,
+                                    error = e.to_string()
+                                );
+                                let _ = disconnect_client_tx.send(());
+                                return;
+                            }
+                            None => {
+                                trace!(message = "client connection closed", client = client_id);
+                                let _ = disconnect_client_tx.send(());
+                                return;
+                            }
+                            _ => {}
+                        }
+                    }
+
+                    _ = timeout_checker.tick() => {
+                        if ping_enabled && last_pong.elapsed() > pong_timeout  {
+                            debug!(
+                                message = "client pong timeout, disconnecting",
+                                client = client_id,
+                                elapsed_ms = last_pong.elapsed().as_millis()
+                            );
+                            metrics.client_pong_disconnects.increment(1);
+                            let _ = disconnect_client_tx.send(());
+                            return;
+                        }
                     }
                 }
             }
-
-            metrics.closed_connections.increment(1);
-            info!(message = "client disconnected", client = client.id());
-        });
+        })
     }
 }

--- a/crates/websocket-proxy/tests/integration.rs
+++ b/crates/websocket-proxy/tests/integration.rs
@@ -1,3 +1,4 @@
+use axum::extract::ws::Message;
 use futures::StreamExt;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -26,7 +27,7 @@ struct TestHarness {
     server: Server,
     server_addr: SocketAddr,
     client_id_to_handle: HashMap<usize, JoinHandle<()>>,
-    sender: Sender<Vec<u8>>,
+    sender: Sender<Message>,
 }
 
 impl TestHarness {
@@ -42,7 +43,7 @@ impl TestHarness {
     fn new_with_auth(addr: SocketAddr, auth: Option<Authentication>) -> TestHarness {
         let (sender, _) = broadcast::channel(5);
         let metrics = Arc::new(Metrics::default());
-        let registry = Registry::new(sender.clone(), metrics.clone());
+        let registry = Registry::new(sender.clone(), metrics.clone(), false, 120000);
         let rate_limited = Arc::new(InMemoryRateLimit::new(3, 10));
 
         Self {
@@ -148,14 +149,37 @@ impl TestHarness {
         client_id
     }
 
-    fn send_messages(&mut self, messages: Vec<&str>) {
-        let messages: Vec<Vec<u8>> = messages
-            .into_iter()
-            .map(|m| m.as_bytes().to_vec())
-            .collect();
+    fn connect_unresponsive_client(&mut self) -> usize {
+        let uri = format!("ws://{}/ws", self.server_addr);
 
-        for message in messages.iter() {
-            match self.sender.send(message.clone()) {
+        let client_id = self.current_client_id;
+        self.current_client_id += 1;
+
+        let failed_conns = self.clients_failed_to_connect.clone();
+
+        let handle = tokio::spawn(async move {
+            let (_ws_stream, _) = match connect_async(uri).await {
+                Ok(results) => results,
+                Err(_) => {
+                    failed_conns.lock().unwrap().insert(client_id, true);
+                    return;
+                }
+            };
+
+            // Do nothing - just keep the connection alive but don't read messages or respond to pings
+            loop {
+                tokio::time::sleep(Duration::from_millis(1000)).await;
+            }
+        });
+
+        self.client_id_to_handle.insert(client_id, handle);
+        client_id
+    }
+
+    fn send_messages(&mut self, messages: Vec<&str>) {
+        for message_str in messages.iter() {
+            let message = Message::Binary(message_str.as_bytes().to_vec().into());
+            match self.sender.send(message) {
                 Ok(_) => {}
                 Err(_) => {
                     assert!(false)
@@ -346,4 +370,44 @@ async fn test_authentication_allows_known_api_keys() {
     assert!(harness.can_connect("ws/key2").await);
     assert!(harness.can_connect("ws/key3").await);
     assert!(!(harness.can_connect("ws/key4").await));
+}
+
+#[tokio::test]
+async fn test_ping_timeout_disconnects_client() {
+    let addr = TestHarness::alloc_port().await;
+
+    let (sender, _) = broadcast::channel(5);
+    let metrics = Arc::new(Metrics::default());
+    let registry = Registry::new(sender.clone(), metrics.clone(), true, 1000);
+    let rate_limited = Arc::new(InMemoryRateLimit::new(3, 10));
+
+    let mut harness = TestHarness {
+        received_messages: Arc::new(Mutex::new(HashMap::new())),
+        clients_failed_to_connect: Arc::new(Mutex::new(HashMap::new())),
+        current_client_id: 0,
+        cancel_token: CancellationToken::new(),
+        server: Server::new(
+            addr,
+            registry,
+            metrics,
+            rate_limited,
+            None,
+            "header".to_string(),
+        ),
+        server_addr: addr,
+        client_id_to_handle: HashMap::new(),
+        sender,
+    };
+
+    harness.start_server().await;
+
+    let _client_id = harness.connect_unresponsive_client();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    assert_eq!(harness.sender.receiver_count(), 1);
+
+    harness.sender.send(Message::Ping(vec![].into())).unwrap();
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    assert_eq!(harness.sender.receiver_count(), 0);
 }


### PR DESCRIPTION
### Description
Add the option to periodically ping clients and disconnect any that don't respond with a pong within a configurable time period. 

Most clients would be disconnected before this, due to lagging by not receiving Flashblocks. However this adds a second line of defense if there's ever a Flashblocks outage.