### PR TITLE
Add metrics and message log to track number of flashblocks used

### DIFF
--- a/crates/rollup-boost/src/flashblocks/metrics.rs
+++ b/crates/rollup-boost/src/flashblocks/metrics.rs
@@ -1,4 +1,4 @@
-use metrics::{Counter, Gauge};
+use metrics::{Counter, Gauge, Histogram};
 use metrics_derive::Metrics;
 
 #[derive(Metrics, Clone)]
@@ -27,4 +27,7 @@ pub struct FlashblocksServiceMetrics {
 
     #[metric(describe = "Number of messages processed by the service")]
     pub messages_processed: Counter,
+
+    #[metric(describe = "Number of flashblocks used to build a block")]
+    pub flashblocks_used: Histogram,
 }

--- a/crates/rollup-boost/src/flashblocks/service.rs
+++ b/crates/rollup-boost/src/flashblocks/service.rs
@@ -228,6 +228,11 @@ impl FlashblocksService {
         // consume the best payload and reset the builder
         let payload = {
             let mut builder = self.best_payload.write().await;
+            let flashblocks_number = builder.flashblocks.len();
+            self.metrics
+                .flashblocks_used
+                .record(flashblocks_number as f64);
+            tracing::Span::current().record("flashblocks_count", flashblocks_number);
             // Take payload and place new one in its place in one go to avoid double locking
             std::mem::replace(&mut *builder, FlashblockBuilder::new()).into_envelope(version)?
         };

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -438,6 +438,7 @@ where
             gas_delta,
             tx_count_delta,
             builder_has_payload,
+            flashblocks_count,
         )
     )]
     async fn get_payload_v3(


### PR DESCRIPTION
Needed to track how good the timings are
closes https://github.com/flashbots/rollup-boost/issues/238
