### PR TITLE
feat: tracing improvements

### DIFF
--- a/crates/rollup-boost/src/cli.rs
+++ b/crates/rollup-boost/src/cli.rs
@@ -17,7 +17,7 @@ use crate::{
     client::rpc::{BuilderArgs, L2ClientArgs},
     debug_api::ExecutionMode,
     get_version, init_metrics,
-    payload::PayloadSource,
+    payload::ExecutionClient,
     probe::ProbeLayer,
 };
 
@@ -117,7 +117,7 @@ impl RollupBoostArgs {
             l2_client_args.l2_url.clone(),
             l2_auth_jwt,
             l2_client_args.l2_timeout,
-            PayloadSource::L2,
+            ExecutionClient::Sequencer,
         )?;
 
         let builder_args = self.builder;
@@ -133,7 +133,7 @@ impl RollupBoostArgs {
             builder_args.builder_url.clone(),
             builder_auth_jwt,
             builder_args.builder_timeout,
-            PayloadSource::Builder,
+            ExecutionClient::Builder,
         )?;
 
         let (probe_layer, probes) = ProbeLayer::new();

--- a/crates/rollup-boost/src/flashblocks/service.rs
+++ b/crates/rollup-boost/src/flashblocks/service.rs
@@ -380,7 +380,7 @@ impl EngineApiExt for FlashblocksService {
 mod tests {
     use super::*;
     use crate::{
-        PayloadSource,
+        ExecutionClient,
         server::tests::{MockEngineServer, spawn_server},
     };
     use http::Uri;
@@ -399,7 +399,7 @@ mod tests {
             builder_auth_rpc.clone(),
             jwt_secret,
             2000,
-            PayloadSource::Builder,
+            ExecutionClient::Builder,
         )?;
 
         let service =
@@ -428,7 +428,7 @@ mod tests {
             builder_auth_rpc.clone(),
             jwt_secret,
             2000,
-            PayloadSource::Builder,
+            ExecutionClient::Builder,
         )?;
 
         let service =

--- a/crates/rollup-boost/src/health.rs
+++ b/crates/rollup-boost/src/health.rs
@@ -140,7 +140,7 @@ mod tests {
     use tokio::net::TcpListener;
 
     use super::*;
-    use crate::{Probes, payload::PayloadSource};
+    use crate::{Probes, payload::ExecutionClient};
 
     pub struct MockHttpServer {
         addr: SocketAddr,
@@ -272,7 +272,7 @@ mod tests {
             format!("http://{}", builder.addr).parse::<Uri>()?,
             JwtSecret::random(),
             100,
-            PayloadSource::Builder,
+            ExecutionClient::Builder,
         )?);
 
         let health_handle = HealthHandle {
@@ -303,7 +303,7 @@ mod tests {
             format!("http://{}", builder.addr).parse::<Uri>()?,
             JwtSecret::random(),
             100,
-            PayloadSource::Builder,
+            ExecutionClient::Builder,
         )?);
 
         let health_handle = HealthHandle {
@@ -335,7 +335,7 @@ mod tests {
             format!("http://{}", builder.addr).parse::<Uri>()?,
             JwtSecret::random(),
             100,
-            PayloadSource::Builder,
+            ExecutionClient::Builder,
         )?);
 
         let health_handle = HealthHandle {
@@ -367,7 +367,7 @@ mod tests {
             format!("http://{}", builder.addr).parse::<Uri>()?,
             JwtSecret::random(),
             100,
-            PayloadSource::Builder,
+            ExecutionClient::Builder,
         )?);
 
         let health_handle = HealthHandle {
@@ -392,7 +392,7 @@ mod tests {
             "http://127.0.0.1:6000".parse::<Uri>()?,
             JwtSecret::random(),
             100,
-            PayloadSource::Builder,
+            ExecutionClient::Builder,
         )?);
 
         let health_handle = HealthHandle {

--- a/crates/rollup-boost/src/payload.rs
+++ b/crates/rollup-boost/src/payload.rs
@@ -147,28 +147,28 @@ impl PayloadVersion {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PayloadSource {
-    L2,
+pub enum ExecutionClient {
+    Sequencer,
     Builder,
 }
 
-impl std::fmt::Display for PayloadSource {
+impl std::fmt::Display for ExecutionClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            PayloadSource::L2 => write!(f, "l2"),
-            PayloadSource::Builder => write!(f, "builder"),
+            ExecutionClient::Sequencer => write!(f, "sequencer"),
+            ExecutionClient::Builder => write!(f, "builder"),
         }
     }
 }
 
 #[allow(dead_code)]
-impl PayloadSource {
+impl ExecutionClient {
     pub fn is_builder(&self) -> bool {
-        matches!(self, PayloadSource::Builder)
+        matches!(self, ExecutionClient::Builder)
     }
 
     pub fn is_l2(&self) -> bool {
-        matches!(self, PayloadSource::L2)
+        matches!(self, ExecutionClient::Sequencer)
     }
 }
 

--- a/crates/rollup-boost/src/proxy.rs
+++ b/crates/rollup-boost/src/proxy.rs
@@ -1,5 +1,5 @@
 use crate::client::http::HttpClient;
-use crate::payload::PayloadSource;
+use crate::payload::ExecutionClient;
 use crate::{Request, Response, from_buffered_request, into_buffered_request};
 use alloy_rpc_types_engine::JwtSecret;
 use http::Uri;
@@ -60,14 +60,14 @@ impl<S> Layer<S> for ProxyLayer {
         let l2_client = HttpClient::new(
             self.l2_auth_rpc.clone(),
             self.l2_auth_secret,
-            PayloadSource::L2,
+            ExecutionClient::Sequencer,
             self.l2_timeout,
         );
 
         let builder_client = HttpClient::new(
             self.builder_auth_rpc.clone(),
             self.builder_auth_secret,
-            PayloadSource::Builder,
+            ExecutionClient::Builder,
             self.builder_timeout,
         );
 


### PR DESCRIPTION
# Changes

### - prefer inheriting event attributes from span attributes

##### Example
```rust
    #[instrument(level = "info")]
    fn hello(hello: &str) {
        tracing::info!("Hello World!");
    }
```
is formatted as
```json
{"timestamp":"2025-07-17T19:48:25.889430Z","level":"INFO","fields":{"message":"Hello World!"},"target":"rollup_boost::tracing::tests","span":{"hello":"world","name":"hello"},"spans":[{"hello":"world","name":"hello"}]}
```

### - set `level = "info"` for `#[instrument]`

This ensures the spans will always be created for use in metrics and logging

### - rearrange tracing init

This is done so that span metrics can work independently from `tracing` being enabled