### PR TITLE
Always send get_payload to builder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 
 on:
-  workflow_dispatch:
   push:
     tags:
       - 'v*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.FLASHBOTS_GHCR_TOKEN }} # PAT required for Organization policy
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
             type=sha
             type=pep440,pattern={{version}}
             type=pep440,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ !contains(env.RELEASE_VERSION, '-') }}
+            type=raw,value=latest,enable=${{ !contains(env.RELEASE_VERSION, '-rc') }}
 
       - name: Create manifest list and push
         working-directory: /tmp/digests

--- a/crates/rollup-boost/src/flashblocks/service.rs
+++ b/crates/rollup-boost/src/flashblocks/service.rs
@@ -363,6 +363,8 @@ impl EngineApiExt for FlashblocksService {
     ) -> ClientResult<OpExecutionPayloadEnvelope> {
         // First try to get the best flashblocks payload from the builder if it exists
 
+        // We always send get_payload to ensure that builder knows when to stop build job
+        let builder_payload = self.client.get_payload(payload_id, version).await?;
         match self.get_best_payload(version, payload_id).await {
             Ok(payload) => {
                 info!(message = "Returning fb payload");
@@ -371,8 +373,7 @@ impl EngineApiExt for FlashblocksService {
             Err(e) => {
                 error!(message = "Error getting fb best payload, falling back on client", error = %e);
                 info!(message = "Falling back to get_payload on client", payload_id = %payload_id);
-                let result = self.client.get_payload(payload_id, version).await?;
-                Ok(result)
+                Ok(builder_payload)
             }
         }
     }

--- a/crates/rollup-boost/src/flashblocks/service.rs
+++ b/crates/rollup-boost/src/flashblocks/service.rs
@@ -366,7 +366,6 @@ impl EngineApiExt for FlashblocksService {
         match self.get_best_payload(version, payload_id).await {
             Ok(payload) => {
                 info!(message = "Returning fb payload");
-                info!(message = "Sending getPayload to build to stop building process");
                 // This will finalise block building in builder.
                 let client = self.client.clone();
                 tokio::spawn(async move {


### PR DESCRIPTION
We encountered a problem that if builder does not receive getPayload it will not preserve current executed block to the cache. This change fix this, but adds a little bit of latency in the hot path of flashblocks