### PR TITLE
POC: fix FCU avalance by using different builder with limited connection

### DIFF
--- a/crates/rollup-boost/src/cli.rs
+++ b/crates/rollup-boost/src/cli.rs
@@ -118,6 +118,15 @@ impl RollupBoostArgs {
             l2_auth_jwt,
             l2_client_args.l2_timeout,
             PayloadSource::L2,
+            None,
+        )?;
+
+        let l2_fcu_client = RpcClient::new(
+            l2_client_args.l2_url.clone(),
+            l2_auth_jwt,
+            l2_client_args.l2_timeout,
+            PayloadSource::L2,
+            Some(100)
         )?;
 
         let builder_args = self.builder;
@@ -134,6 +143,15 @@ impl RollupBoostArgs {
             builder_auth_jwt,
             builder_args.builder_timeout,
             PayloadSource::Builder,
+            None,
+        )?;
+
+        let builder_fcu_client = RpcClient::new(
+            builder_args.builder_url.clone(),
+            builder_auth_jwt,
+            builder_args.builder_timeout,
+            PayloadSource::Builder,
+            Some(100),
         )?;
 
         let (probe_layer, probes) = ProbeLayer::new();
@@ -157,6 +175,8 @@ impl RollupBoostArgs {
             let rollup_boost = RollupBoostServer::new(
                 l2_client,
                 builder_client,
+                l2_fcu_client,
+                builder_fcu_client,
                 execution_mode.clone(),
                 self.block_selection_policy,
                 probes.clone(),
@@ -172,6 +192,8 @@ impl RollupBoostArgs {
             let rollup_boost = RollupBoostServer::new(
                 l2_client,
                 Arc::new(builder_client),
+                l2_fcu_client,
+                builder_fcu_client,
                 execution_mode.clone(),
                 self.block_selection_policy,
                 probes.clone(),

--- a/crates/rollup-boost/src/flashblocks/service.rs
+++ b/crates/rollup-boost/src/flashblocks/service.rs
@@ -410,6 +410,7 @@ mod tests {
             jwt_secret,
             2000,
             PayloadSource::Builder,
+            None,
         )?;
 
         let service =
@@ -439,6 +440,7 @@ mod tests {
             jwt_secret,
             2000,
             PayloadSource::Builder,
+            None,
         )?;
 
         let service =

--- a/crates/rollup-boost/src/health.rs
+++ b/crates/rollup-boost/src/health.rs
@@ -273,6 +273,7 @@ mod tests {
             JwtSecret::random(),
             100,
             PayloadSource::Builder,
+            None,
         )?);
 
         let health_handle = HealthHandle {
@@ -304,6 +305,7 @@ mod tests {
             JwtSecret::random(),
             100,
             PayloadSource::Builder,
+            None,
         )?);
 
         let health_handle = HealthHandle {
@@ -336,6 +338,7 @@ mod tests {
             JwtSecret::random(),
             100,
             PayloadSource::Builder,
+            None,
         )?);
 
         let health_handle = HealthHandle {
@@ -368,6 +371,7 @@ mod tests {
             JwtSecret::random(),
             100,
             PayloadSource::Builder,
+            None,
         )?);
 
         let health_handle = HealthHandle {
@@ -393,6 +397,7 @@ mod tests {
             JwtSecret::random(),
             100,
             PayloadSource::Builder,
+            None,
         )?);
 
         let health_handle = HealthHandle {


### PR DESCRIPTION
We created different rpc client with limited connection number to proxy all FCU without attributes trough it.

This will offload them from critical rpc client and won't cause huge spike in connections