### PR TITLE
chore: namespace and rename gh workflows

### DIFF
--- a/.github/workflows/common-build-docker-image.yml
+++ b/.github/workflows/common-build-docker-image.yml
@@ -1,4 +1,4 @@
-name: Build Docker Image
+name: "[common] Build Docker Image"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/common-lint.yml
+++ b/.github/workflows/common-lint.yml
@@ -1,4 +1,4 @@
-name: Linting
+name: "[common] Lint"
 
 on:
   push:
@@ -32,4 +32,3 @@ jobs:
 
       - name: Deny
         uses: EmbarkStudios/cargo-deny-action@v2
-

--- a/.github/workflows/common-tests.yml
+++ b/.github/workflows/common-tests.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: "[common] Tests"
 
 on:
   push:

--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -1,7 +1,7 @@
 # Documentation and mdbook related jobs.
 # Heavily inspired by Reth https://github.com/paradigmxyz/reth/blob/main/.github/workflows/book.yml
 
-name: book-tests
+name: "[docs] Checks"
 
 on:
   pull_request:

--- a/.github/workflows/rb-builder-playground-integration-tests.yml
+++ b/.github/workflows/rb-builder-playground-integration-tests.yml
@@ -1,4 +1,4 @@
-name: Builder Playground Integration Tests
+name: "[rollup-boost] Builder Playground Integration Tests"
 
 on:
   # Allow manual trigger

--- a/.github/workflows/rb-kurtosis-integration-tests.yml
+++ b/.github/workflows/rb-kurtosis-integration-tests.yml
@@ -1,4 +1,4 @@
-name: Kurtosis Integration Tests
+name: "[rollup-boost] Kurtosis Integration Tests"
 
 on:
   # Allow manual trigger

--- a/.github/workflows/rb-release.yml
+++ b/.github/workflows/rb-release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: "[rollup-boost] Release"
 
 on:
   push:
@@ -35,7 +35,7 @@ jobs:
           echo "| \`GITHUB_SHA\`      | \`${GITHUB_SHA}\`      |" >> $GITHUB_STEP_SUMMARY
           echo "| \`VERSION\`         | \`${VERSION}\`         |" >> $GITHUB_STEP_SUMMARY
           echo "| \`FEATURES\`        | \`${{ github.event.inputs.features || 'none' }}\` |" >> $GITHUB_STEP_SUMMARY
-        
+
   build-binary:
     name: Build binary
     needs: extract-version

--- a/.github/workflows/wp-checks.yml
+++ b/.github/workflows/wp-checks.yml
@@ -1,4 +1,4 @@
-name: Websocket Proxy CI
+name: "[websocket-proxy] Checks"
 
 on:
   push:

--- a/.github/workflows/wp-release.yml
+++ b/.github/workflows/wp-release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: "[websocket-proxy] Release"
 
 on:
   push:
@@ -35,7 +35,7 @@ jobs:
           echo "| \`GITHUB_SHA\`      | \`${GITHUB_SHA}\`      |" >> $GITHUB_STEP_SUMMARY
           echo "| \`VERSION\`         | \`${VERSION}\`         |" >> $GITHUB_STEP_SUMMARY
           echo "| \`FEATURES\`        | \`${{ github.event.inputs.features || 'none' }}\` |" >> $GITHUB_STEP_SUMMARY
-        
+
   build-binary:
     name: Build binary
     needs: extract-version
@@ -108,7 +108,7 @@ jobs:
           platform=${{ matrix.configs.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
           echo "RELEASE_VERSION=${{ needs.extract-version.outputs.VERSION }}" >> $GITHUB_ENV
-          
+
       - name: Print version
         run: |
           echo $RELEASE_VERSION


### PR DESCRIPTION
now that the present repo hosts 3 different products (`rollup-boost`, `flashblocks-rpc`, and `websocket-proxy`) it becase a bit confusing to teel which gh workflow is for which product.

this PR addresses that.