### PR TITLE
fix spec metadata structure

### DIFF
--- a/crates/flashblocks-rpc/README.md
+++ b/crates/flashblocks-rpc/README.md
@@ -17,10 +17,10 @@ cargo build --release
 Run:
 
 ```bash
-./target/release/flashblocks-rpc \
-    --flashblocks.enabled=true \
-    --flashblocks.websocket-url=ws://localhost:8080/flashblocks \
-    --chain=optimism \
+./target/release/flashblocks-rpc node \
+    --flashblocks.enabled \
+    --flashblocks.websocket-url="wss://sepolia-flashblocks.unichain.org/ws" \
+    --chain=unichain-sepolia \
     --http \
     --http.port=8545
 ```


### PR DESCRIPTION
The `FlashblockMetadata` described in the spec is different from the implementation. I assumed the implementation is correct, and have updated the spec to reflect the implementation. 

Transaction receipts included in the flashblocks metadata are serialized from the following enum [defined here][op-receipt].

```rust
pub enum OpReceipt {
    /// Legacy receipt
    Legacy(Receipt),
    /// EIP-2930 receipt
    Eip2930(Receipt),
    /// EIP-1559 receipt
    Eip1559(Receipt),
    /// EIP-7702 receipt
    Eip7702(Receipt),
    /// Deposit receipt
    Deposit(OpDepositReceipt),
}
```

[op-receipt]: https://github.com/paradigmxyz/reth/blob/main/crates/optimism/primitives/src/receipt.rs#L17-L32

This does not translate to Python succinctly so I opted to show it in Rust. I think that it makes sense to update the spec to show all of the types in Rust to make it easy to translate to the code stored in the repo, and I'm happy to make that change if it's agreed.