### PR TITLE
refactor: Enable library usage of rollup-boost

### DIFF
--- a/crates/rollup-boost/src/flashblocks/mod.rs
+++ b/crates/rollup-boost/src/flashblocks/mod.rs
@@ -4,9 +4,9 @@ pub use launcher::*;
 
 mod primitives;
 mod service;
+pub use service::*;
 
 pub use primitives::*;
-pub use service::*;
 
 mod inbound;
 mod outbound;

--- a/crates/rollup-boost/src/flashblocks/service.rs
+++ b/crates/rollup-boost/src/flashblocks/service.rs
@@ -164,7 +164,7 @@ impl FlashblockBuilder {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct FlashblocksService {
     client: RpcClient,
 

--- a/crates/rollup-boost/src/payload.rs
+++ b/crates/rollup-boost/src/payload.rs
@@ -239,6 +239,7 @@ pub struct PayloadTrace {
     pub trace_id: Option<tracing::Id>,
 }
 
+#[derive(Debug)]
 pub struct PayloadTraceContext {
     block_hash_to_payload_ids: Cache<B256, Vec<PayloadId>>,
     payload_id: Cache<PayloadId, PayloadTrace>,

--- a/crates/rollup-boost/src/probe.rs
+++ b/crates/rollup-boost/src/probe.rs
@@ -62,7 +62,7 @@ pub struct ProbeLayer {
 }
 
 impl ProbeLayer {
-    pub(crate) fn new() -> (Self, Arc<Probes>) {
+    pub fn new() -> (Self, Arc<Probes>) {
         let probes = Arc::new(Probes::default());
         (
             Self {


### PR DESCRIPTION
- **Summary**: Consolidates RPC client configuration into a reusable `ClientArgs` type and refactors CLI, server, and proxy wiring to construct typed RPC/HTTP clients from args. Simplifies `ProxyLayer` to accept prebuilt HTTP clients, adds constructor helpers for `RollupBoostServer`, and improves health/debug startup orchestration.

- **Key changes**
  - Introduce `ClientArgs` with helpers to build clients:
    - `client/rpc.rs`: adds `ClientArgs`, `new_rpc_client`, `new_http_client`, and `define_client_args!` macro to generate `BuilderArgs`/`L2ClientArgs` with consistent flags.
  - Refactor server/CLI construction:
    - `server.rs`: add `RollupBoostServer::<FlashblocksService>::new_from_args` and `RollupBoostServer::<RpcClient>::new_from_args` that validate the `flashblocks` mode and build the appropriate clients; move `ExecutionMode` initialization into `new` and call `update_execution_mode_gauge`.
    - `cli.rs`: build `ClientArgs` from clap args; create `l2_http_client` and `builder_http_client`; start the `DebugServer` from the CLI after constructing `RollupBoostServer`; wire middleware with `ProbeLayer` and the new `ProxyLayer`.
  - Simplify proxy wiring:
    - `proxy.rs`: change `ProxyLayer::new` to accept `HttpClient` instances for L2 and builder rather than URIs/JWT; forward rules unchanged; tests updated to construct clients via `ClientArgs`.
  - Minor cleanups:
    - `flashblocks/mod.rs`: tidy exports.
    - `payload.rs`: make `PayloadTraceContext` and related structs `Debug`.
    - `probe.rs`: return probes from `ProbeLayer::new()` for simpler wiring.
    - `cli.rs`: implement `Default` for `RollupBoostArgs` to aid testing.

- **Breaking changes**
  - `ProxyLayer::new` signature now takes `(l2_client: HttpClient, builder_client: HttpClient)`. All call sites updated.
  - Code constructing `RpcClient`/`HttpClient` should use `ClientArgs` or the new helpers.

- **Operational impact**
  - Behavior is unchanged functionally; startup is cleaner and mode-checked. Health and debug endpoints are initialized from the CLI after server construction.
  - Metrics now record initial execution mode at construction via `update_execution_mode_gauge`.

- **Testing**
  - Updated proxy tests to use `ClientArgs` and the new `ProxyLayer::new`.
  - Added/expanded tests for:
    - Forwarding paths (miner/eth send) and engine passthrough.
    - L2 server recovery and success/failure transitions.
    - Health status behavior under builder/L2 API failures and external state root flow.
  - Server tests now build both RPC and HTTP clients from `ClientArgs` and exercise new constructors.

- **Migration notes**
  - Replace prior `ProxyLayer::new(uri, jwt, ...)` usage with HTTP clients created via:
    - `ClientArgs::new_http_client(PayloadSource::L2|Builder)`
  - Prefer constructing `RollupBoostServer` via `new_from_args` helpers when possible.