### PR TITLE
chore(deps): update alloy/op-reth dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1953,9 +1953,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.4"
+version = "2.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "137a2a2878ed823ef1bd73e5441e245602aae5360022113b8ad259ca4b5b8727"
+checksum = "e00bf4b112b07b505472dbefd19e37e53307e2bfed5a79e0cc161d58ccd0e687"
 dependencies = [
  "arbitrary",
  "blst",
@@ -2643,7 +2643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.104",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7008,8 +7008,8 @@ checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7032,8 +7032,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7063,8 +7063,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7083,8 +7083,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -7097,8 +7097,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7172,8 +7172,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -7182,8 +7182,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7199,8 +7199,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7219,8 +7219,8 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7229,8 +7229,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7244,8 +7244,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7257,8 +7257,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7269,8 +7269,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7295,8 +7295,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7321,8 +7321,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7349,8 +7349,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7379,8 +7379,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7394,8 +7394,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7419,8 +7419,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7443,8 +7443,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -7467,8 +7467,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7502,8 +7502,8 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7560,8 +7560,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7591,8 +7591,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7615,8 +7615,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7640,8 +7640,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-service"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "futures",
  "pin-project",
@@ -7662,8 +7662,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7717,8 +7717,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7745,8 +7745,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7761,8 +7761,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7776,8 +7776,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7798,8 +7798,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7809,8 +7809,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7837,8 +7837,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7858,8 +7858,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7874,8 +7874,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7892,8 +7892,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -7905,8 +7905,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7934,8 +7934,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7954,8 +7954,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -7964,8 +7964,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7987,8 +7987,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8007,8 +8007,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -8020,8 +8020,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8038,8 +8038,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8076,8 +8076,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8090,8 +8090,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "serde",
  "serde_json",
@@ -8100,8 +8100,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8128,8 +8128,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "bytes",
  "futures",
@@ -8148,8 +8148,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "bitflags 2.10.0",
  "byteorder",
@@ -8164,8 +8164,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -8173,8 +8173,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "futures",
  "metrics",
@@ -8185,16 +8185,16 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-primitives",
 ]
 
 [[package]]
 name = "reth-net-nat"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -8207,8 +8207,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8262,8 +8262,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8287,8 +8287,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8310,8 +8310,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8325,8 +8325,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8339,8 +8339,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8356,8 +8356,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8380,8 +8380,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8432,7 +8432,7 @@ dependencies = [
  "reth-rpc-builder",
  "reth-rpc-engine-api",
  "reth-rpc-eth-types",
- "reth-rpc-layer 1.8.3",
+ "reth-rpc-layer 1.9.0",
  "reth-stages",
  "reth-static-file",
  "reth-tasks",
@@ -8448,8 +8448,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8500,8 +8500,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -8538,8 +8538,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8562,8 +8562,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8586,8 +8586,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "eyre",
  "http",
@@ -8607,8 +8607,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8619,8 +8619,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-chainspec"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8647,8 +8647,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-cli"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8697,8 +8697,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-consensus"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8722,8 +8722,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-evm"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8750,8 +8750,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-flashblocks"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8789,8 +8789,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-forks"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-op-hardforks",
  "alloy-primitives",
@@ -8800,8 +8800,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-node"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8846,8 +8846,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-payload-builder"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8886,8 +8886,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-primitives"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8906,8 +8906,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-rpc"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8949,7 +8949,6 @@ dependencies = [
  "reth-primitives-traits",
  "reth-rpc",
  "reth-rpc-api",
- "reth-rpc-convert",
  "reth-rpc-engine-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
@@ -8968,8 +8967,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-storage"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "reth-optimism-primitives",
@@ -8978,8 +8977,8 @@ dependencies = [
 
 [[package]]
 name = "reth-optimism-txpool"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9014,8 +9013,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9035,8 +9034,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -9047,8 +9046,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9067,8 +9066,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-util"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9077,8 +9076,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -9087,8 +9086,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "c-kzg",
@@ -9101,8 +9100,8 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9134,8 +9133,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9178,8 +9177,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9204,8 +9203,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9219,8 +9218,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -9232,8 +9231,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9311,8 +9310,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -9339,8 +9338,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -9362,7 +9361,7 @@ dependencies = [
  "reth-rpc-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
- "reth-rpc-layer 1.8.3",
+ "reth-rpc-layer 1.9.0",
  "reth-rpc-server-types",
  "reth-storage-api",
  "reth-tasks",
@@ -9378,8 +9377,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -9405,8 +9404,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9435,8 +9434,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -9479,8 +9478,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9540,8 +9539,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-rpc-types-engine",
  "http",
@@ -9554,8 +9553,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9570,8 +9569,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9618,8 +9617,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9645,8 +9644,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9659,8 +9658,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9679,8 +9678,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9691,8 +9690,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9714,8 +9713,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9730,8 +9729,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9748,8 +9747,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9764,8 +9763,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9774,8 +9773,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "clap",
  "eyre",
@@ -9791,8 +9790,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "clap",
  "eyre",
@@ -9808,8 +9807,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9849,8 +9848,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9874,8 +9873,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9901,8 +9900,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -9914,8 +9913,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9939,8 +9938,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9958,8 +9957,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse-parallel"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9976,8 +9975,8 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "1.8.3"
-source = "git+https://github.com/paradigmxyz/reth?rev=c3a60fa#c3a60fa75a30c8b527b63143dc060082bdfee87e"
+version = "1.9.0"
+source = "git+https://github.com/paradigmxyz/reth?tag=v1.9.0#84785f025eac5eed123997454998db77a299e1e5"
 dependencies = [
  "zstd",
 ]
@@ -10337,7 +10336,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "sha2 0.10.9",
+ "sha2",
  "testcontainers",
  "thiserror 2.0.12",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,20 +26,20 @@ sha2 = { version = "0.10", default-features = false }
 backoff = "0.4.0"
 
 # Reth deps
-reth-optimism-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c3a60fa" }
+reth-optimism-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0" }
 
 # Alloy libraries
-alloy-rpc-types-engine = "1.0.42"
-alloy-rpc-types-eth = "1.0.42"
-alloy-primitives = { version = "1.3.1", features = ["rand"] }
-alloy-serde = "1.0.42"
-alloy-eips = "1.0.42"
-alloy-json-rpc = "1.0.42"
-alloy-consensus = "1.0.42"
-alloy-rpc-types = "1.0.42"
-alloy-genesis = "1.0.42"
-alloy-rpc-client = "1.0.42"
-alloy-provider = "1.0.42"
+alloy-rpc-types-engine = "1.1.0"
+alloy-rpc-types-eth = "1.1.0"
+alloy-primitives = { version = "1.4.1", features = ["rand"] }
+alloy-serde = "1.1.0"
+alloy-eips = "1.1.0"
+alloy-json-rpc = "1.1.0"
+alloy-consensus = "1.1.0"
+alloy-rpc-types = "1.1.0"
+alloy-genesis = "1.1.0"
+alloy-rpc-client = "1.1.0"
+alloy-provider = "1.1.0"
 op-alloy-network = "0.22.0"
 op-alloy-rpc-types-engine = "0.22.0"
 op-alloy-consensus = "0.22.0"

--- a/crates/flashblocks-rpc/Cargo.toml
+++ b/crates/flashblocks-rpc/Cargo.toml
@@ -7,27 +7,27 @@ license = "MIT"
 [dependencies]
 rollup-boost.workspace = true
 
-reth-optimism-node = { git = "https://github.com/paradigmxyz/reth", rev = "c3a60fa" }
-reth-optimism-cli = { git = "https://github.com/paradigmxyz/reth", rev = "c3a60fa" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "c3a60fa" }
-reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c3a60fa" }
-reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "c3a60fa" }
-reth-optimism-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "c3a60fa" }
-reth-optimism-evm = { git = "https://github.com/paradigmxyz/reth", rev = "c3a60fa" }
-reth-optimism-forks = { git = "https://github.com/paradigmxyz/reth", rev = "c3a60fa" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "c3a60fa" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c3a60fa" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", rev = "c3a60fa" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c3a60fa", features = [
+reth-optimism-node = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0" }
+reth-optimism-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0" }
+reth-optimism-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0" }
+reth-optimism-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0" }
+reth-optimism-rpc = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0" }
+reth-optimism-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0" }
+reth-optimism-forks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0", features = [
     "test-utils",
 ] }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "c3a60fa" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "c3a60fa" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "c3a60fa" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "c3a60fa" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "c3a60fa" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "c3a60fa" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "c3a60fa" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.0" }
 
 alloy-eips.workspace = true
 alloy-primitives.workspace = true


### PR DESCRIPTION
## Description

Small PR to bump `alloy-rs` and `reth` dependencies.

Tomorrow (Wed Nov 5th), Ithaca will release a new github tag for `reth`/`op-reth`. I will update the commit rev to use the new tag then.

EDIT: Updated `reth`/`op-reth` to `1.9.0`