### PR TITLE
Separate library and service CLI args; flatten lib args into service args

### DIFF
--- a/crates/rollup-boost/src/bin/main.rs
+++ b/crates/rollup-boost/src/bin/main.rs
@@ -1,13 +1,13 @@
 use clap::Parser;
 use dotenvy::dotenv;
-use rollup_boost::RollupBoostArgs;
+use rollup_boost::RollupBoostServiceArgs;
 use rollup_boost::init_tracing;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
     dotenv().ok();
 
-    let args = RollupBoostArgs::parse();
+    let args = RollupBoostServiceArgs::parse();
     init_tracing(&args)?;
     args.run().await
 }

--- a/crates/rollup-boost/src/cli.rs
+++ b/crates/rollup-boost/src/cli.rs
@@ -14,14 +14,32 @@ use crate::{
 };
 use crate::{FlashblocksService, RpcClient};
 
-#[derive(Clone, Parser, Debug)]
-#[clap(author, version = get_version(), about)]
-pub struct RollupBoostArgs {
+#[derive(Clone, Debug, clap::Args)]
+pub struct RollupBoostLibArgs {
     #[clap(flatten)]
     pub builder: BuilderArgs,
 
     #[clap(flatten)]
     pub l2_client: L2ClientArgs,
+
+    /// Execution mode to start rollup boost with
+    #[arg(long, env, default_value = "enabled")]
+    pub execution_mode: ExecutionMode,
+
+    #[arg(long, env)]
+    pub block_selection_policy: Option<BlockSelectionPolicy>,
+
+    /// Should we use the l2 client for computing state root
+    #[arg(long, env, default_value = "false")]
+    pub external_state_root: bool,
+
+    /// Allow all engine API calls to builder even when marked as unhealthy
+    /// This is default true assuming no builder CL set up
+    #[arg(long, env, default_value = "false")]
+    pub ignore_unhealthy_builders: bool,
+
+    #[clap(flatten)]
+    pub flashblocks: FlashblocksArgs,
 
     /// Duration in seconds between async health checks on the builder
     #[arg(long, env, default_value = "60")]
@@ -30,6 +48,13 @@ pub struct RollupBoostArgs {
     /// Max duration in seconds between the unsafe head block of the builder and the current time
     #[arg(long, env, default_value = "10")]
     pub max_unsafe_interval: u64,
+}
+
+#[derive(Clone, Parser, Debug)]
+#[clap(author, version = get_version(), about)]
+pub struct RollupBoostServiceArgs {
+    #[clap(flatten)]
+    pub lib: RollupBoostLibArgs,
 
     /// Host to run the server on
     #[arg(long, env, default_value = "127.0.0.1")]
@@ -78,57 +103,38 @@ pub struct RollupBoostArgs {
     /// Debug server port
     #[arg(long, env, default_value = "5555")]
     pub debug_server_port: u16,
-
-    /// Execution mode to start rollup boost with
-    #[arg(long, env, default_value = "enabled")]
-    pub execution_mode: ExecutionMode,
-
-    #[arg(long, env)]
-    pub block_selection_policy: Option<BlockSelectionPolicy>,
-
-    /// Should we use the l2 client for computing state root
-    #[arg(long, env, default_value = "false")]
-    pub external_state_root: bool,
-
-    /// Allow all engine API calls to builder even when marked as unhealthy
-    /// This is default true assuming no builder CL set up
-    #[arg(long, env, default_value = "false")]
-    pub ignore_unhealthy_builders: bool,
-
-    #[clap(flatten)]
-    pub flashblocks: FlashblocksArgs,
 }
 
-impl RollupBoostArgs {
+impl RollupBoostServiceArgs {
     pub async fn run(self) -> eyre::Result<()> {
         let _ = rustls::crypto::ring::default_provider().install_default();
         init_metrics(&self)?;
 
         let debug_addr = format!("{}:{}", self.debug_host, self.debug_server_port);
-        let l2_client_args: ClientArgs = self.l2_client.clone().into();
+        let l2_client_args: ClientArgs = self.lib.l2_client.clone().into();
         let l2_http_client = l2_client_args.new_http_client(PayloadSource::L2)?;
 
-        let builder_client_args: ClientArgs = self.builder.clone().into();
+        let builder_client_args: ClientArgs = self.lib.builder.clone().into();
         let builder_http_client = builder_client_args.new_http_client(PayloadSource::Builder)?;
 
         let (probe_layer, probes) = ProbeLayer::new();
 
-        let (health_handle, rpc_module) = if self.flashblocks.flashblocks {
+        let (health_handle, rpc_module) = if self.lib.flashblocks.flashblocks {
             let rollup_boost = RollupBoostServer::<FlashblocksService>::new_from_args(
-                self.clone(),
+                self.lib.clone(),
                 probes.clone(),
             )?;
             let health_handle = rollup_boost
-                .spawn_health_check(self.health_check_interval, self.max_unsafe_interval);
+                .spawn_health_check(self.lib.health_check_interval, self.lib.max_unsafe_interval);
             let debug_server = DebugServer::new(rollup_boost.execution_mode.clone());
             debug_server.run(&debug_addr).await?;
             let rpc_module: RpcModule<()> = rollup_boost.try_into()?;
             (health_handle, rpc_module)
         } else {
             let rollup_boost =
-                RollupBoostServer::<RpcClient>::new_from_args(self.clone(), probes.clone())?;
+                RollupBoostServer::<RpcClient>::new_from_args(self.lib.clone(), probes.clone())?;
             let health_handle = rollup_boost
-                .spawn_health_check(self.health_check_interval, self.max_unsafe_interval);
+                .spawn_health_check(self.lib.health_check_interval, self.lib.max_unsafe_interval);
             let debug_server = DebugServer::new(rollup_boost.execution_mode.clone());
             debug_server.run(&debug_addr).await?;
             let rpc_module: RpcModule<()> = rollup_boost.try_into()?;
@@ -180,7 +186,7 @@ impl RollupBoostArgs {
     }
 }
 
-impl Default for RollupBoostArgs {
+impl Default for RollupBoostServiceArgs {
     fn default() -> Self {
         Self::parse_from::<_, &str>(std::iter::empty())
     }

--- a/crates/rollup-boost/src/metrics.rs
+++ b/crates/rollup-boost/src/metrics.rs
@@ -15,9 +15,9 @@ use jsonrpsee::http_client::HttpBody;
 use metrics_exporter_prometheus::PrometheusHandle;
 
 use crate::ExecutionMode;
-use crate::cli::RollupBoostArgs;
+use crate::cli::RollupBoostServiceArgs;
 
-pub fn init_metrics(args: &RollupBoostArgs) -> Result<()> {
+pub fn init_metrics(args: &RollupBoostServiceArgs) -> Result<()> {
     if args.metrics {
         let recorder = PrometheusBuilder::new().build_recorder();
         let handle = recorder.handle();

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -1,7 +1,7 @@
 use crate::debug_api::ExecutionMode;
 use crate::{
     BlockSelectionPolicy, ClientArgs, EngineApiExt, Flashblocks, FlashblocksService,
-    RollupBoostArgs, update_execution_mode_gauge,
+    RollupBoostLibArgs, update_execution_mode_gauge,
 };
 use crate::{
     client::rpc::RpcClient,
@@ -71,7 +71,7 @@ pub struct RollupBoostServer<T: EngineApiExt> {
 
 impl RollupBoostServer<FlashblocksService> {
     pub fn new_from_args(
-        rollup_boost_args: RollupBoostArgs,
+        rollup_boost_args: RollupBoostLibArgs,
         probes: Arc<Probes>,
     ) -> eyre::Result<Self> {
         if !rollup_boost_args.flashblocks.flashblocks {
@@ -113,7 +113,7 @@ impl RollupBoostServer<FlashblocksService> {
 
 impl RollupBoostServer<RpcClient> {
     pub fn new_from_args(
-        rollup_boost_args: RollupBoostArgs,
+        rollup_boost_args: RollupBoostLibArgs,
         probes: Arc<Probes>,
     ) -> eyre::Result<Self> {
         if rollup_boost_args.flashblocks.flashblocks {

--- a/crates/rollup-boost/src/tests/common/mod.rs
+++ b/crates/rollup-boost/src/tests/common/mod.rs
@@ -381,15 +381,15 @@ impl RollupBoostTestHarnessBuilder {
 
         // Start Rollup-boost instance
         let mut rollup_boost = RollupBoostConfig::default();
-        rollup_boost.args.l2_client.l2_url = l2.auth_rpc().await?;
-        rollup_boost.args.builder.builder_url = builder_url.try_into().unwrap();
+        rollup_boost.args.lib.l2_client.l2_url = l2.auth_rpc().await?;
+        rollup_boost.args.lib.builder.builder_url = builder_url.try_into().unwrap();
         rollup_boost.args.log_file = Some(rollup_boost_log_file_path);
-        rollup_boost.args.external_state_root = self.external_state_root;
+        rollup_boost.args.lib.external_state_root = self.external_state_root;
         if let Some(allow_traffic) = self.ignore_unhealthy_builders {
-            rollup_boost.args.ignore_unhealthy_builders = allow_traffic;
+            rollup_boost.args.lib.ignore_unhealthy_builders = allow_traffic;
         }
         if let Some(interval) = self.max_unsafe_interval {
-            rollup_boost.args.max_unsafe_interval = interval;
+            rollup_boost.args.lib.max_unsafe_interval = interval;
         }
         let rollup_boost = rollup_boost.start().await;
         println!("rollup-boost authrpc: {}", rollup_boost.rpc_endpoint());

--- a/crates/rollup-boost/src/tests/common/services/rollup_boost.rs
+++ b/crates/rollup-boost/src/tests/common/services/rollup_boost.rs
@@ -1,7 +1,6 @@
 use std::{fs::File, time::Duration};
 
-use crate::RollupBoostArgs;
-use clap::Parser;
+use crate::RollupBoostServiceArgs;
 use tokio::task::JoinHandle;
 use tracing::subscriber::DefaultGuard;
 use tracing_subscriber::fmt;
@@ -10,13 +9,13 @@ use crate::tests::common::{TEST_DATA, get_available_port};
 
 #[derive(Debug)]
 pub struct RollupBoost {
-    args: RollupBoostArgs,
+    args: RollupBoostServiceArgs,
     pub _handle: JoinHandle<eyre::Result<()>>,
     pub _tracing_guard: DefaultGuard,
 }
 
 impl RollupBoost {
-    pub fn args(&self) -> &RollupBoostArgs {
+    pub fn args(&self) -> &RollupBoostServiceArgs {
         &self.args
     }
 
@@ -41,12 +40,12 @@ impl RollupBoost {
 
 #[derive(Clone, Debug)]
 pub struct RollupBoostConfig {
-    pub args: RollupBoostArgs,
+    pub args: RollupBoostServiceArgs,
 }
 
 impl Default for RollupBoostConfig {
     fn default() -> Self {
-        let mut args = RollupBoostArgs::parse_from([
+        let mut args = <RollupBoostServiceArgs as clap::Parser>::parse_from([
             "rollup-boost",
             &format!("--l2-jwt-path={}/jwt_secret.hex", *TEST_DATA),
             &format!("--builder-jwt-path={}/jwt_secret.hex", *TEST_DATA),

--- a/crates/rollup-boost/src/tracing.rs
+++ b/crates/rollup-boost/src/tracing.rs
@@ -12,7 +12,7 @@ use tracing_subscriber::filter::Targets;
 use tracing_subscriber::fmt::writer::BoxMakeWriter;
 use tracing_subscriber::layer::SubscriberExt;
 
-use crate::cli::{LogFormat, RollupBoostArgs};
+use crate::cli::{LogFormat, RollupBoostServiceArgs};
 
 /// Span attribute keys that should be recorded as metric labels.
 ///
@@ -99,7 +99,7 @@ impl SpanProcessor for MetricsSpanProcessor {
     }
 }
 
-pub fn init_tracing(args: &RollupBoostArgs) -> eyre::Result<()> {
+pub fn init_tracing(args: &RollupBoostServiceArgs) -> eyre::Result<()> {
     // Be cautious with snake_case and kebab-case here
     let filter_name = "rollup_boost".to_string();
 


### PR DESCRIPTION
**Modifies no behavior; not a breaking change**

- Split `RollupBoostArgs` into `RollupBoostLibArgs` (library) and `RollupBoostServiceArgs` (service).
- `RollupBoostServiceArgs` flattens `RollupBoostLibArgs` via clap; existing CLI flags unchanged.
- Updated server constructors and tracing/metrics init to use new types.
- CLI users: no changes. Library users: migrate to `RollupBoostLibArgs` / `RollupBoostServiceArgs`.