### PR TITLE
feat: expose probes in RollupBoostServer

### DIFF
--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -163,6 +163,10 @@ impl<T: EngineApiExt> RollupBoostServer<T> {
         }
     }
 
+    pub fn probes(&self) -> Arc<Probes> {
+        self.probes.clone()
+    }
+
     pub fn spawn_health_check(
         &self,
         health_check_interval: u64,


### PR DESCRIPTION
Exposes a publlic getter function for `probes` in `RollupBoostServer`

Part of https://github.com/op-rs/kona/issues/3053