### PR TITLE
dockerfile: default service_name to be 'rollup-boost'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 FROM gcr.io/distroless/cc-debian12
 WORKDIR /app
 
-ARG SERVICE_NAME
+ARG SERVICE_NAME="rollup-boost"
 # Copy binary with its proper service name
 COPY --from=builder /tmp/final_binary /usr/local/bin/${SERVICE_NAME}
 # Also copy as a fixed entrypoint name


### PR DESCRIPTION
Signed-off-by: Yashvardhan Kukreja <yashvardhan@oplabs.co>

We noticed that the newly built rollup-boost image by flashbots doesn't have a binary /usr/local/bin/rollup-boost at its entrypoint.
That's because there's no default value of "rollup-boost" of it (as opposed to the previous docker build stage). Semantically, it would be a pretty sane default to have imo.

This PR achieves that.