### PR TITLE
feat: add get and set execution mode

### DIFF
--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -184,6 +184,14 @@ impl<T: EngineApiExt> RollupBoostServer<T> {
         handle.spawn()
     }
 
+    pub fn set_execution_mode(&self, execution_mode: ExecutionMode) {
+        *self.execution_mode.lock() = execution_mode;
+    }
+
+    pub fn get_execution_mode(&self) -> ExecutionMode {
+        *self.execution_mode.lock()
+    }
+
     async fn new_payload(&self, new_payload: NewPayload) -> RpcResult<PayloadStatus> {
         let execution_payload = ExecutionPayload::from(new_payload.clone());
         let block_hash = execution_payload.block_hash();


### PR DESCRIPTION
Adds public functions `get_execution_mode` and `set_execution_mode` to `RollupBoostServer`

Context: https://github.com/op-rs/kona/pull/3085#discussion_r2586456741