### PR TITLE
Revamp builder-playground usage

### DIFF
--- a/.github/workflows/rb-builder-playground-integration-tests.yml
+++ b/.github/workflows/rb-builder-playground-integration-tests.yml
@@ -43,4 +43,4 @@ jobs:
           args: --skip-setup
 
       - name: Send test tx to the builder
-        run: builder-playground test http://localhost:8547 --timeout 2m --retries 100
+        run: builder-playground test --rpc http://localhost:8547 --timeout 30s --retries 20

--- a/.github/workflows/rb-builder-playground-integration-tests.yml
+++ b/.github/workflows/rb-builder-playground-integration-tests.yml
@@ -43,4 +43,4 @@ jobs:
           args: --skip-setup
 
       - name: Send test tx to the builder
-        run: builder-playground test http://localhost:8547 --timeout 30s --retries 10
+        run: builder-playground test http://localhost:8547 --timeout 2m --retries 100

--- a/.github/workflows/rb-builder-playground-integration-tests.yml
+++ b/.github/workflows/rb-builder-playground-integration-tests.yml
@@ -22,11 +22,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install Builder playground
-        uses: flashbots/flashbots-toolchain@v0.2
-        with:
-          builder-playground: latest
-
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -40,6 +35,12 @@ jobs:
         run: |
           just build
 
-      - name: Run Builder Playground
-        run: |
-          builder-playground cook opstack --override rollup-boost=flashbots/rollup-boost:develop --external-builder op-reth --timeout 5m --watchdog
+      - name: Run rollup-boost with builder-playground
+        uses: flashbots/builder-playground-action@v1
+        with:
+          version: v0.3.2-alpha.7
+          recipe: playground.yaml
+          args: --skip-setup
+
+      - name: Send test tx to the builder
+        run: builder-playground test http://localhost:8547 --timeout 30s --retries 10

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Run the rollup-boost server using the following command:
 cargo run --bin rollup-boost -- [OPTIONS]
 ```
 
+or together with OP Stack by using builder-playground:
+
+```
+builder-playground start playground.yaml
+```
+
 ### Command-line Options
 
 - `--l2-jwt-token <TOKEN>`: JWT token for L2 authentication (required)

--- a/playground.yaml
+++ b/playground.yaml
@@ -1,0 +1,33 @@
+base: opstack
+description: Run locally-built rollup-boost with the OP stack recipe
+
+base_args:
+  - --external-builder
+  - op-reth
+
+setup:
+  - just build
+
+recipe:
+  rollup-boost:
+    services:
+      rollup-boost:
+        image: flashbots/rollup-boost
+        tag: develop
+        # args:
+        #   - --rpc-host
+        #   - 0.0.0.0
+        #   - --rpc-port
+        #   - '{{Port "authrpc" 8551}}'
+        #   - --l2-jwt-path
+        #   - /data/jwtsecret
+        #   - --l2-url
+        #   - '{{Service "op-geth" "authrpc" "http" ""}}'
+        #   - --builder-jwt-path
+        #   - /data/jwtsecret
+        #   - --builder-url
+        #   - '{{Service "op-reth" "authrpc" "http" ""}}'
+        # ports:
+        #   authrpc: 8551
+        # files:
+        #   /data/jwtsecret: artifact:jwtsecret


### PR DESCRIPTION
- Using a new configurable recipe file for local runs and in CI
- Mentioning the option to run with the recipe file in the README
- Using the new builder-playground github action in the CI, together with the recipe, and verifying with test tx