### PR TITLE
fix: pin FLASHBLOCKS env var names to preserve backward compatibility

### DIFF
--- a/crates/rollup-boost/src/cli.rs
+++ b/crates/rollup-boost/src/cli.rs
@@ -203,12 +203,17 @@ impl std::str::FromStr for LogFormat {
 #[cfg(test)]
 pub mod tests {
     use std::result::Result;
+    use std::sync::Mutex;
 
     use super::*;
 
     const SECRET: &str = "f79ae8046bc11c9927afe911db7143c51a806c4a537cc08e0d37140b0192f430";
     const FLASHBLOCKS_SK: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
     const FLASHBLOCKS_VK: &str = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210";
+
+    /// Tests that mutate the `FLASHBLOCKS` env var must hold this lock to avoid
+    /// racing with tests that assert the default (unset) state.
+    static FLASHBLOCKS_ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_parse_args_minimal() -> Result<(), Box<dyn std::error::Error>> {
@@ -384,8 +389,86 @@ pub mod tests {
     }
 
     #[test]
+    fn test_flashblocks_env_var_contract() -> Result<(), Box<dyn std::error::Error>> {
+        // Pin the public env-var contract for every FLASHBLOCKS* arg. If a future
+        // refactor renames any of these fields without explicitly setting `env =`,
+        // clap will silently rename the env var and this test will catch it.
+        type Check = fn(&RollupBoostServiceArgs) -> bool;
+        let cases: &[(&str, &str, Check)] = &[
+            ("FLASHBLOCKS", "true", |a| {
+                a.lib.flashblocks_ws.flashblocks_ws
+            }),
+            ("FLASHBLOCKS_BUILDER_URL", "ws://10.0.0.1:9000", |a| {
+                a.lib.flashblocks_ws.flashblocks_builder_url.as_str() == "ws://10.0.0.1:9000/"
+            }),
+            ("FLASHBLOCKS_HOST", "10.0.0.2", |a| {
+                a.lib.flashblocks_ws.flashblocks_host == "10.0.0.2"
+            }),
+            ("FLASHBLOCKS_PORT", "9999", |a| {
+                a.lib.flashblocks_ws.flashblocks_port == 9999
+            }),
+            ("FLASHBLOCK_BUILDER_WS_INITIAL_RECONNECT_MS", "42", |a| {
+                a.lib
+                    .flashblocks_ws
+                    .flashblocks_ws_config
+                    .flashblock_builder_ws_initial_reconnect_ms
+                    == 42
+            }),
+            ("FLASHBLOCK_BUILDER_WS_MAX_RECONNECT_MS", "43", |a| {
+                a.lib
+                    .flashblocks_ws
+                    .flashblocks_ws_config
+                    .flashblock_builder_ws_max_reconnect_ms
+                    == 43
+            }),
+            ("FLASHBLOCK_BUILDER_WS_CONNECT_TIMEOUT_MS", "44", |a| {
+                a.lib
+                    .flashblocks_ws
+                    .flashblocks_ws_config
+                    .flashblock_builder_ws_connect_timeout_ms
+                    == 44
+            }),
+            ("FLASHBLOCK_BUILDER_WS_PING_INTERVAL_MS", "45", |a| {
+                a.lib
+                    .flashblocks_ws
+                    .flashblocks_ws_config
+                    .flashblock_builder_ws_ping_interval_ms
+                    == 45
+            }),
+            ("FLASHBLOCK_BUILDER_WS_PONG_TIMEOUT_MS", "46", |a| {
+                a.lib
+                    .flashblocks_ws
+                    .flashblocks_ws_config
+                    .flashblock_builder_ws_pong_timeout_ms
+                    == 46
+            }),
+        ];
+
+        let _guard = FLASHBLOCKS_ENV_LOCK.lock().unwrap();
+        for (var, val, check) in cases {
+            // SAFETY: env mutation, serialized via FLASHBLOCKS_ENV_LOCK.
+            unsafe { std::env::set_var(var, val) };
+            let parsed = RollupBoostServiceArgs::try_parse_from([
+                "rollup-boost",
+                "--builder-jwt-token",
+                SECRET,
+                "--l2-jwt-token",
+                SECRET,
+            ]);
+            unsafe { std::env::remove_var(var) };
+            let parsed = parsed.unwrap_or_else(|e| panic!("{var}={val} failed to parse: {e}"));
+            assert!(
+                check(&parsed),
+                "{var}={val} did not propagate to the parsed value"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
     fn test_parse_args_flashblocks_ws_absent_defaults_false()
     -> Result<(), Box<dyn std::error::Error>> {
+        let _guard = FLASHBLOCKS_ENV_LOCK.lock().unwrap();
         let args = RollupBoostServiceArgs::try_parse_from([
             "rollup-boost",
             "--builder-jwt-token",

--- a/crates/rollup-boost/src/flashblocks/args.rs
+++ b/crates/rollup-boost/src/flashblocks/args.rs
@@ -10,25 +10,28 @@ use hex::FromHex;
 pub struct FlashblocksWsArgs {
     /// Enable Flashblocks Websocket client
     #[arg(
-        // Keep the flag as "flashblocks" for backward compatibility
         long = "flashblocks",
         id = "flashblocks_ws",
         conflicts_with = "flashblocks_p2p",
-        env,
+        env = "FLASHBLOCKS",
         required = false
     )]
     pub flashblocks_ws: bool,
 
     /// Flashblocks Builder WebSocket URL
-    #[arg(long, env, default_value = "ws://127.0.0.1:1111")]
+    #[arg(
+        long,
+        env = "FLASHBLOCKS_BUILDER_URL",
+        default_value = "ws://127.0.0.1:1111"
+    )]
     pub flashblocks_builder_url: Url,
 
     /// Flashblocks WebSocket host for outbound connections
-    #[arg(long, env, default_value = "127.0.0.1")]
+    #[arg(long, env = "FLASHBLOCKS_HOST", default_value = "127.0.0.1")]
     pub flashblocks_host: String,
 
     /// Flashblocks WebSocket port for outbound connections
-    #[arg(long, env, default_value = "1112")]
+    #[arg(long, env = "FLASHBLOCKS_PORT", default_value = "1112")]
     pub flashblocks_port: u16,
 
     /// Websocket connection configuration
@@ -39,23 +42,43 @@ pub struct FlashblocksWsArgs {
 #[derive(Args, Debug, Clone, Copy)]
 pub struct FlashblocksWebsocketConfig {
     /// Minimum time for exponential backoff for timeout if builder disconnected
-    #[arg(long, env, default_value = "10")]
+    #[arg(
+        long,
+        env = "FLASHBLOCK_BUILDER_WS_INITIAL_RECONNECT_MS",
+        default_value = "10"
+    )]
     pub flashblock_builder_ws_initial_reconnect_ms: u64,
 
     /// Maximum time for exponential backoff for timeout if builder disconnected
-    #[arg(long, env, default_value = "5000")]
+    #[arg(
+        long,
+        env = "FLASHBLOCK_BUILDER_WS_MAX_RECONNECT_MS",
+        default_value = "5000"
+    )]
     pub flashblock_builder_ws_max_reconnect_ms: u64,
 
     /// Timeout for connection attempt
-    #[arg(long, env, default_value = "5000")]
+    #[arg(
+        long,
+        env = "FLASHBLOCK_BUILDER_WS_CONNECT_TIMEOUT_MS",
+        default_value = "5000"
+    )]
     pub flashblock_builder_ws_connect_timeout_ms: u64,
 
     /// Interval in milliseconds between ping messages sent to upstream servers to detect unresponsive connections
-    #[arg(long, env, default_value = "500")]
+    #[arg(
+        long,
+        env = "FLASHBLOCK_BUILDER_WS_PING_INTERVAL_MS",
+        default_value = "500"
+    )]
     pub flashblock_builder_ws_ping_interval_ms: u64,
 
     /// Timeout in milliseconds to wait for pong responses from upstream servers before considering the connection dead
-    #[arg(long, env, default_value = "1500")]
+    #[arg(
+        long,
+        env = "FLASHBLOCK_BUILDER_WS_PONG_TIMEOUT_MS",
+        default_value = "1500"
+    )]
     pub flashblock_builder_ws_pong_timeout_ms: u64,
 }
 
@@ -100,7 +123,7 @@ pub struct FlashblocksP2PArgs {
         long,
         id = "flashblocks_p2p",
         conflicts_with = "flashblocks_ws",
-        env,
+        env = "FLASHBLOCKS_P2P",
         required = false
     )]
     pub flashblocks_p2p: bool,


### PR DESCRIPTION
## Summary                                                                                                        
                                                                                                                    
  Restore `FLASHBLOCKS=true` as the env var that enables the flashblocks WebSocket client, and defensively pin every   other `FLASHBLOCKS*` env name so a future field rename cannot silently break the public env contract again.
                                                                                                                    
  ## Motivation                                                          
                                                                                                                    
  [#373](https://github.com/flashbots/rollup-boost/pull/373) renamed the field `FlashblocksArgs::flashblocks` →  `FlashblocksWsArgs::flashblocks_ws` and added `id = "flashblocks_ws"`. clap derives the env-var name from `id`  when `env` is left bare, so the public env var silently changed from `FLASHBLOCKS` to `FLASHBLOCKS_WS`. The CLI  flag (`--flashblocks`) was preserved via explicit `long = "flashblocks"` but the env path was missed.