### PR TITLE
release: bump rollup-boost to 0.7.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4358,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "rollup-boost"
-version = "0.7.15"
+version = "0.7.16"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4428,7 +4428,7 @@ dependencies = [
 
 [[package]]
 name = "rollup-boost-types"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 [workspace.dependencies]
 rollup-boost = { path = "crates/rollup-boost" }
 flashblocks-rpc = { path = "crates/flashblocks-rpc" }
-rollup-boost-types = { version = "0.2.0", path = "crates/rollup-boost-types" }
+rollup-boost-types = { version = "0.3.0", path = "crates/rollup-boost-types" }
 
 backoff = "0.4.0"
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/rollup-boost-types/Cargo.toml
+++ b/crates/rollup-boost-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rollup-boost-types"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 description = "Core types for Rollup Boost"
 license = "MIT"

--- a/crates/rollup-boost/Cargo.toml
+++ b/crates/rollup-boost/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rollup-boost"
-version = "0.7.15"
+version = "0.7.16"
 edition = "2024"
 description = "Rollup Boost is a sidecar for optimism rollups that enables rollup extensions"
 rust-version = "1.94"


### PR DESCRIPTION
## Release: rollup-boost v0.7.16

Version bump for the next release.

- `rollup-boost` 0.7.15 → **0.7.16**
- `rollup-boost-types` 0.2.0 → **0.3.0** (breaking: adds public `PayloadVersion::V5` variant; the enum is not `#[non_exhaustive]`, so this can break downstream exhaustive matches)

### Changes included since v0.7.15
- Make rollup-boost compatible with upcoming version of op-node (#488)
- Add engine exchange capabilities support (#487)
- docs: add CONTRIBUTING.md (#486)
- fix health check (#477)
- fix: pin FLASHBLOCKS env var names to preserve backward compatibility (#485)

🤖 Generated with [Claude Code](https://claude.com/claude-code)