### PR TITLE
release: bump rollup-boost to 0.7.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4338,7 +4338,7 @@ dependencies = [
 
 [[package]]
 name = "rollup-boost"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",

--- a/crates/rollup-boost/Cargo.toml
+++ b/crates/rollup-boost/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rollup-boost"
-version = "0.7.16"
+version = "0.7.17"
 edition = "2024"
 description = "Rollup Boost is a sidecar for optimism rollups that enables rollup extensions"
 rust-version = "1.94"


### PR DESCRIPTION
Bump rollup-boost 0.7.16 -> 0.7.17. rollup-boost-types is unchanged since 0.7.16 and stays at 0.3.0.

Contains three fixes, all in the builder payload path:

- flashblocks payload id mismatch fcu race (#491)
- require explicit VALID before selecting the builder payload (#492)
- health and external state root fixes (#493)